### PR TITLE
Add PR action and associated fixes to get it working

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -1,0 +1,46 @@
+name: PR
+
+on:
+  pull_request:
+    branches:
+      - master
+    paths:
+      - ni_python_styleguide
+      - poetry.lock
+      - pyproject.toml
+
+jobs:
+  pr:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+    - name: Check Poetry Metadata
+      uses: abatilo/actions-poetry@v1.5.0
+      with:
+        python_version: 3.5.0
+        poetry_version: 1.0
+        args: check
+
+    # @TODO: This is a workaround for there not being a way to check the lock file
+    #   See: https://github.com/python-poetry/poetry/issues/453
+    #   NOTE: We're taking advantage of the fact that "abatilo/actions-poetry"
+    #     has been run, installs poetry globally, and uses pyenv
+    - name: Check for lock changes
+      run: |
+        pyenv latest local 3.5.0
+        python -c "from poetry.factory import Factory; l = Factory().create_poetry('.').locker; exit(0) if l.is_locked() and l.is_fresh() else exit(1)" && echo 'OK'
+
+    - name: Install the Package
+      uses: abatilo/actions-poetry@v1.5.0
+      with:
+        python_version: 3.5.0
+        poetry_version: 1.0
+        args: install
+
+    - name: Lint the Code
+      uses: abatilo/actions-poetry@v1.5.0
+      with:
+        python_version: 3.5.0
+        poetry_version: 1.0
+        args: run ni-python-styleguide lint 

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -24,11 +24,9 @@ jobs:
 
       # @TODO: This is a workaround for there not being a way to check the lock file
       #   See: https://github.com/python-poetry/poetry/issues/453
-      #   NOTE: We're taking advantage of the fact that "abatilo/actions-poetry"
-      #     has been run, installs poetry globally, and uses pyenv
       - name: Check for lock changes
         run: |
-          pyenv latest local 3.5.8
+          pip install poetry==1.0
           python -c " \
             from poetry.factory import Factory; \
             locker = Factory().create_poetry('.').locker; \

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -24,8 +24,11 @@ jobs:
 
       # @TODO: This is a workaround for there not being a way to check the lock file
       #   See: https://github.com/python-poetry/poetry/issues/453
+      #   NOTE: This isn't ideal as it using the system Python and dirtying the system
+      #     Python libraries.
       - name: Check for lock changes
         run: |
+          pip install poetry==1.0
           python -c "from poetry.factory import Factory; \
             locker = Factory().create_poetry('.').locker; \
             exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -29,7 +29,11 @@ jobs:
       - name: Check for lock changes
         run: |
           pyenv latest local 3.5.8
-          python -c "from poetry.factory import Factory; l = Factory().create_poetry('.').locker; exit(0) if l.is_locked() and l.is_fresh() else exit(1)" && echo 'OK'
+          python -c " \
+            from poetry.factory import Factory; \
+            locker = Factory().create_poetry('.').locker; \
+            exit(0) if locker.is_locked() and locker.is_fresh() else exit(1) \
+          " && echo 'OK'
 
       - name: Install the Package
         uses: abatilo/actions-poetry@v1.5.0

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -24,14 +24,15 @@ jobs:
 
       # @TODO: This is a workaround for there not being a way to check the lock file
       #   See: https://github.com/python-poetry/poetry/issues/453
+      #   NOTE: This isn't ideal as it using the system Python and dirtying the system
+      #     Python libraries.
       - name: Check for lock changes
         run: |
           pip install poetry==1.0
-          python -c " \
-            from poetry.factory import Factory; \
+          python -c "from poetry.factory import Factory; \
             locker = Factory().create_poetry('.').locker; \
-            exit(0) if locker.is_locked() and locker.is_fresh() else exit(1) \
-          " && echo 'OK'
+            exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \
+            && echo 'OK'
 
       - name: Install the Package
         uses: abatilo/actions-poetry@v1.5.0

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -15,35 +15,24 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Check Poetry Metadata
-        uses: abatilo/actions-poetry@v1.5.0
+      - uses: actions/setup-python@v1
         with:
-          python_version: 3.5.8
-          poetry_version: 1.0
-          args: check
+          python-version: 3.5
+      - uses: Gr1N/setup-poetry@v2
+        with:
+          poetry-version: 1.0.0
 
       # @TODO: This is a workaround for there not being a way to check the lock file
       #   See: https://github.com/python-poetry/poetry/issues/453
-      #   NOTE: This isn't ideal as it using the system Python and dirtying the system
-      #     Python libraries.
       - name: Check for lock changes
         run: |
-          pip install poetry==1.0
           python -c "from poetry.factory import Factory; \
             locker = Factory().create_poetry('.').locker; \
             exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \
             && echo 'OK'
 
       - name: Install the Package
-        uses: abatilo/actions-poetry@v1.5.0
-        with:
-          python_version: 3.5.8
-          poetry_version: 1.0
-          args: install
+        run: poetry install
 
       - name: Lint the Code
-        uses: abatilo/actions-poetry@v1.5.0
-        with:
-          python_version: 3.5.8
-          poetry_version: 1.0
-          args: run ni-python-styleguide lint
+        run: poetry run ni-python-styleguide lint

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -17,7 +17,7 @@ jobs:
 
       - uses: actions/setup-python@v1
         with:
-          python-version: 3.5
+          python-version: 3.6
       - uses: Gr1N/setup-poetry@v2
         with:
           poetry-version: 1.0.0

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/setup-python@v1
         with:
           python-version: 3.6
+
       - uses: Gr1N/setup-poetry@v2
         with:
           poetry-version: 1.0.0

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Check Poetry Metadata
         uses: abatilo/actions-poetry@v1.5.0
         with:
-          python_version: 3.5.0
+          python_version: 3.5.8
           poetry_version: 1.0
           args: check
 
@@ -28,19 +28,19 @@ jobs:
       #     has been run, installs poetry globally, and uses pyenv
       - name: Check for lock changes
         run: |
-          pyenv latest local 3.5.0
+          pyenv latest local 3.5.8
           python -c "from poetry.factory import Factory; l = Factory().create_poetry('.').locker; exit(0) if l.is_locked() and l.is_fresh() else exit(1)" && echo 'OK'
 
       - name: Install the Package
         uses: abatilo/actions-poetry@v1.5.0
         with:
-          python_version: 3.5.0
+          python_version: 3.5.8
           poetry_version: 1.0
           args: install
 
       - name: Lint the Code
         uses: abatilo/actions-poetry@v1.5.0
         with:
-          python_version: 3.5.0
+          python_version: 3.5.8
           poetry_version: 1.0
           args: run ni-python-styleguide lint

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -15,32 +15,32 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-    - name: Check Poetry Metadata
-      uses: abatilo/actions-poetry@v1.5.0
-      with:
-        python_version: 3.5.0
-        poetry_version: 1.0
-        args: check
+      - name: Check Poetry Metadata
+        uses: abatilo/actions-poetry@v1.5.0
+        with:
+          python_version: 3.5.0
+          poetry_version: 1.0
+          args: check
 
-    # @TODO: This is a workaround for there not being a way to check the lock file
-    #   See: https://github.com/python-poetry/poetry/issues/453
-    #   NOTE: We're taking advantage of the fact that "abatilo/actions-poetry"
-    #     has been run, installs poetry globally, and uses pyenv
-    - name: Check for lock changes
-      run: |
-        pyenv latest local 3.5.0
-        python -c "from poetry.factory import Factory; l = Factory().create_poetry('.').locker; exit(0) if l.is_locked() and l.is_fresh() else exit(1)" && echo 'OK'
+      # @TODO: This is a workaround for there not being a way to check the lock file
+      #   See: https://github.com/python-poetry/poetry/issues/453
+      #   NOTE: We're taking advantage of the fact that "abatilo/actions-poetry"
+      #     has been run, installs poetry globally, and uses pyenv
+      - name: Check for lock changes
+        run: |
+          pyenv latest local 3.5.0
+          python -c "from poetry.factory import Factory; l = Factory().create_poetry('.').locker; exit(0) if l.is_locked() and l.is_fresh() else exit(1)" && echo 'OK'
 
-    - name: Install the Package
-      uses: abatilo/actions-poetry@v1.5.0
-      with:
-        python_version: 3.5.0
-        poetry_version: 1.0
-        args: install
+      - name: Install the Package
+        uses: abatilo/actions-poetry@v1.5.0
+        with:
+          python_version: 3.5.0
+          poetry_version: 1.0
+          args: install
 
-    - name: Lint the Code
-      uses: abatilo/actions-poetry@v1.5.0
-      with:
-        python_version: 3.5.0
-        poetry_version: 1.0
-        args: run ni-python-styleguide lint
+      - name: Lint the Code
+        uses: abatilo/actions-poetry@v1.5.0
+        with:
+          python_version: 3.5.0
+          poetry_version: 1.0
+          args: run ni-python-styleguide lint

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -43,4 +43,4 @@ jobs:
       with:
         python_version: 3.5.0
         poetry_version: 1.0
-        args: run ni-python-styleguide lint 
+        args: run ni-python-styleguide lint

--- a/ni_python_styleguide/_vendor/README.md
+++ b/ni_python_styleguide/_vendor/README.md
@@ -18,3 +18,4 @@ The following PRs are required:
 
 - https://github.com/life4/flakehell/pull/86
 - https://github.com/life4/flakehell/pull/91
+- https://github.com/life4/flakehell/pull/92

--- a/ni_python_styleguide/_vendor/flakehell/_logic/_config.py
+++ b/ni_python_styleguide/_vendor/flakehell/_logic/_config.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 # external
 import toml
 import urllib3
+from flake8.utils import normalize_paths
 
 
 def read_config(*paths) -> Dict[str, Any]:
@@ -59,5 +60,8 @@ def _parse_config(content: str) -> Dict[str, Any]:
         if not isinstance(paths, list):
             paths = [paths]
         config = _merge_configs(read_config(*paths), config)
+
+    if 'exclude' in config:
+        config['exclude'] = normalize_paths(config['exclude'])
 
     return config

--- a/poetry.lock
+++ b/poetry.lock
@@ -26,14 +26,6 @@ version = "0.4.3"
 
 [[package]]
 category = "main"
-description = "Discover and load entry points from installed packages."
-name = "entrypoints"
-optional = false
-python-versions = ">=2.7"
-version = "0.3"
-
-[[package]]
-category = "main"
 description = "the modular source code checker: pep8 pyflakes and co"
 name = "flake8"
 optional = false
@@ -202,7 +194,8 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "698cb4af16734ce495fdc498ebcb91fe685c231accb4f0b3947e5077727c8580"
+content-hash = "2791cf1873ec7a1936ffc2faeb9a075ed32e9a5c3d62445e8188291fd9c13e57"
+lock-version = "1.0"
 python-versions = "^3.5"
 
 [metadata.files]
@@ -213,10 +206,6 @@ astroid = [
 colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
-]
-entrypoints = [
-    {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
-    {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
 ]
 flake8 = [
     {file = "flake8-3.8.3-py2.py3-none-any.whl", hash = "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -186,17 +186,17 @@ description = "Backport of pathlib-compatible object wrapper for zip files"
 marker = "python_version < \"3.8\""
 name = "zipp"
 optional = false
-python-versions = ">=2.7"
-version = "1.2.0"
+python-versions = ">=3.6"
+version = "3.1.0"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pathlib2", "unittest2", "jaraco.itertools", "func-timeout"]
+testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "2791cf1873ec7a1936ffc2faeb9a075ed32e9a5c3d62445e8188291fd9c13e57"
+content-hash = "046262a939b47fb466e3b62870c259abcfff9a99923c168674008cf53b7c75c8"
 lock-version = "1.0"
-python-versions = "^3.5"
+python-versions = "^3.6"
 
 [metadata.files]
 astroid = [
@@ -304,6 +304,6 @@ wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
 ]
 zipp = [
-    {file = "zipp-1.2.0-py2.py3-none-any.whl", hash = "sha256:e0d9e63797e483a30d27e09fffd308c59a700d365ec34e93cc100844168bf921"},
-    {file = "zipp-1.2.0.tar.gz", hash = "sha256:c70410551488251b0fee67b460fb9a536af8d6f9f008ad10ac51f615b6a521b1"},
+    {file = "zipp-3.1.0-py3-none-any.whl", hash = "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b"},
+    {file = "zipp-3.1.0.tar.gz", hash = "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"},
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 include = ["ni_python_styleguide/flakehell_config.toml"]
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.6"
 flake8 = "^3.8.3"
 
 # @TODO: flakehell's dependencies.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,24 @@ urllib3 = "*"
 [tool.poetry.scripts]
 ni-python-styleguide = 'ni_python_styleguide.__main__:main'
 
+# @TODO: flakehell's entrypoints
+[tool.poetry.plugins."flake8.extension"]
+pylint = "ni_python_styleguide._vendor.flakehell.plugins:PyLintChecker"
+
+# @TODO: flakehell's entrypoints
+[tool.poetry.plugins."flake8.report"]
+baseline = "ni_python_styleguide._vendor.flakehell.formatters:BaseLineFormatter"
+colored = "ni_python_styleguide._vendor.flakehell.formatters:ColoredFormatter"
+gitlab = "ni_python_styleguide._vendor.flakehell.formatters:GitlabFormatter"
+grouped = "ni_python_styleguide._vendor.flakehell.formatters:GroupedFormatter"
+json = "ni_python_styleguide._vendor.flakehell.formatters:JSONFormatter"
+stat = "ni_python_styleguide._vendor.flakehell.formatters:StatFormatter"
+
+
+[tool.flakehell]
+exclude = ["ni_python_styleguide/_vendor", ".venv", "docs"]
+show_source = true
+
 [build-system]
-requires = ["poetry_core>=1.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"


### PR DESCRIPTION
This will allow us to runs several checks on the code and files when a new PR comes in. It also leverages the tool to lint the tool which I think is admirable.

Non-yaml changes are those required to get everything up and running. They are:

- PR \#92 to flakehell was made and applied to the vendored copy to allow subdirectory exclusions
- Since we're vendoring flakehell, we also need to define its `entry_points` (`plugins` in `poetry`)
- The lock file was out of date, so I updated it
- The build system was no longer valid so I updated it with what the docs recommend
