### PR TITLE
Don't use a hyphen in PEP 8

### DIFF
--- a/docs/Coding-Conventions.md
+++ b/docs/Coding-Conventions.md
@@ -41,7 +41,7 @@ In all cases where a convention comes from a PEP, it will be marked as such.
 
 ## Guides considered
 
-- [PEP-8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)
+- [PEP 8 -- Style Guide for Python Code](https://www.python.org/dev/peps/pep-0008/)
 
 ---
 
@@ -53,13 +53,13 @@ In all cases where a convention comes from a PEP, it will be marked as such.
 
 ### [F.1.1] ✔️ **DO** Use 4 spaces per indentation level (never tabs)
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ## [F.2] Line Spacing
 
 ### [F.2.1] ✔️ **DO** Use a line break before a binary operator
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 This not only matches mathematical publications, but also results in more readable code:
 
@@ -89,15 +89,15 @@ directors = (
 
 ### [F.2.2] ✔️ **DO** Surround top-level function and class definitions with two blank lines
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [F.2.3] ✔️ **DO** Surround method definitions inside a class by a single blank line
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [F.2.4] ✔️ **DO** Use blank lines in functions, sparingly, to indicate logical sections.
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad - no spaces to form logical breaks in code
@@ -141,7 +141,7 @@ def visit_argument_room(duration):
 
 ### [F.2.4] ❌ **DO NOT** Put multiple statements on one line
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -162,7 +162,7 @@ argue_about_paying()
 
 ### [F.3.1] ❌ **DO NOT** Use whitespace immediately inside parentheses, brackets or braces
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -174,7 +174,7 @@ spam(ham[1], {eggs: 2})
 
 ### [F.3.2] ❌ **DO NOT** Use whitespace between a trailing comma and a following close parenthesis
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -186,7 +186,7 @@ spam = (0,)
 
 ### [F.3.3] ❌ **DO NOT** Use whitespace immediately before a comma, semicolon, or colon
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ℹ️ An exception is made (and **must** be followed) for situations where the colon is acting like a binary operator and other operators are present. Then it **must** be surrounded by whitespace like any other operator.
 
@@ -213,7 +213,7 @@ ham[:upper]
 
 ### [F.3.4] ❌ **DO NOT** Use whitespace immediately before the open parenthesis that starts the argument list of a function call
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -225,7 +225,7 @@ spam(1)
 
 ### [F.3.5] ❌ **DO NOT** Use whitespace immediately before the open parenthesis that starts an indexing or slicing
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -237,11 +237,11 @@ spam['bacon'] = ham[index]
 
 ### [F.3.6] ❌ **DO NOT** Use trailing whitespace anywhere
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [F.3.7] ✔️ **DO** Surround binary operators with exactly one space on either side (unless otherwise stated)
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ℹ️ Rules [F.3.9] and [F.3.10] specify exceptions to this rule
 
@@ -257,7 +257,7 @@ other_order = egg & bacon & spam
 
 ### [F.3.8] ✔️ **CONSIDER** Surrounding expressions with parenthesis when different operators are used
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -270,7 +270,7 @@ order = (spam + bacon) & (sausage + spam)
 
 ### [F.3.9] ❌ **DO NOT** Surround the "`=`" with spaces when used to indicate a keyword argument, or when used to indicate a default value for an _unannotated_ function parameter
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -284,7 +284,7 @@ def argue(room, minutes=5):
 
 ### [F.3.10] ✔️ **DO** Surround the "`=`" with spaces when used to indicate a default value for an _annotated_ function parameter
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -298,7 +298,7 @@ def argue(duration: datetime.timedelta = 5): ...
 
 ### [F.4.1] ✔️ **DO** Parenthesize one-element tuples
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -310,7 +310,7 @@ ingredients = (spam,)
 
 ### [F.4.2] ✔️ **CONSIDER** Using redundant trailing commas in collection element and argument lists
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 This can be helpful for minimizing diffs when future additions are made.
 
@@ -340,7 +340,7 @@ def count(
 
 ### [F.4.3] ❌ **DO NOT** Use a redundant trailing comma on the same line as a closing delimiter
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -351,7 +351,7 @@ order = [egg, sausage, bacon,]
 
 ### [F.5.1] ✔️ **DO** Use single or double quotes characters when a string contains the other character
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -366,7 +366,7 @@ grounding = "'O' Level Geography"
 
 ### [F.5.2] ✔️ **DO** Use double quotes characters for triple-quoted strings
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008) as well as [PEP-257](https://www.python.org/dev/peps/pep-0257)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008) as well as [PEP-257](https://www.python.org/dev/peps/pep-0257)
 
 ```python
 notice = """We apologise for the fault in the subtitles.
@@ -383,7 +383,7 @@ Those responsible have been sacked.
 
 ### [N.1.1] ✔️ **DO** Use ASCII characters for all identifiers
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -392,7 +392,7 @@ møøse_costumes = "Siggi Churchill"
 
 ### [N.1.2] ✔️ **DO** Use a trailing underscore to avoid a name clash with a reserved keyword
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ❗️ In most situations, a _better_ name for the identifier is the solution. This rule only applies for cases where the keyword is the best name (I.e. referencing the built-in operation/element, like [`operator.and_`](https://docs.python.org/3.4/library/operator.html#operator.and_))
 
@@ -409,7 +409,7 @@ file_
 
 ### [N.2.1] ✔️ **DO** Use short, all-lowercase package and module names (Underscores are permissible, but should be avoided)
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -424,11 +424,11 @@ tempfile
 
 ### [N.2.2] ✔️ **DO** Use `snake_case` for function, variable, and parameter names
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [N.2.3] ✔️ **DO** Use CamelCase for class names
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ℹ️ An exception is made for classes which are used primarily as a callable. They should use function naming conventions instead.
 
@@ -444,7 +444,7 @@ class CheeseShop:
 
 ### [N.2.4] ✔️ **DO** Use `CamelCase` for type variable names
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 from typing import TypeVar
@@ -458,7 +458,7 @@ FlyingCircus = TypeVar("FlyingCircus")
 
 ### [N.2.5] ✔️ **DO** Suffix covariant and contravariant type variables with `_co` and `_contra` respectively
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 from typing import TypeVar
@@ -469,27 +469,27 @@ FlyingCircus_contra = TypeVar('FlyingCircus_contra', contravariant=True)
 
 ### [N.2.6] ✔️ **DO** Suffix error exceptions with "Error"
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [N.2.7] ✔️ **DO** Use `self` as the first argument to instance methods
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [N.2.8] ✔️ **DO** Use `cls` as the first argument to class methods
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [N.2.9] ✔️ **DO** Use one leading underscore only for non-public methods and instance variables
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [N.2.10] ✔️ **DO** Use `SCREAMING_CASE` for module level constants
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [N.2.11] ✔️ **CONSIDER** Using two leading underscores for truly private attributes when defining a base class
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ℹ️ This invokes Python's name mangling which does have well-known, yet unintended side-effects. See [the docs](https://docs.python.org/3.6/tutorial/classes.html#private-variables)
 
@@ -501,7 +501,7 @@ FlyingCircus_contra = TypeVar('FlyingCircus_contra', contravariant=True)
 
 ### [L.1.1] ✔️ **DO** Use `is` or `is not` when comparing against a singleton (like `None`)
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -513,7 +513,7 @@ if cheese is None: ...
 
 ### [L.1.2] ✔️ **DO** Use `isinstance` instead of comparing types directly
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -525,7 +525,7 @@ if isinstance(cheese, Gorgonzola): ...
 
 ### [L.1.3] ✔️ **DO** Use the conversion to boolean to check for empty sequences
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 > ‼️ Keep in mind that `None` also converts to `False`. Take care when dealing with `Optional` sequences.
 
@@ -543,7 +543,7 @@ if not seq: ...
 
 ### [L.2.1] ❌ **DO NOT** Assign a lambda expression directly to an identifier
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -558,13 +558,13 @@ def respond():
 
 ### [L.3.1] ✔️ **DO** Derive exceptions from `Exception`
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ℹ️ An exception is made for exceptions which aren't meant to be caught, in which case `BaseException` must be derived from. This should be extremely rare.
 
 ### [L.3.2] ✔️ **DO** Chain exceptions appropriately
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 When re-rasing an exception from an exception block, prefer `raise` over `raise x`.
 
@@ -574,7 +574,7 @@ When deliberately replacing an inner exception (`raise X from None`), ensure tha
 
 ### [L.3.3] ✔️ **DO** Provide an exception type when catching exceptions
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 Additionally, be as specific as possible.
 
@@ -591,7 +591,7 @@ except ImportError: ...
 
 ### [L.3.4] ✔️ **DO** Limit the body of the try block to the absolute minimum amount of code necessary to cause the possible exception
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -613,7 +613,7 @@ else:
 
 ### [L.3.5] ❌ **DO NOT** Use flow control statements (`return`/`break`/`continue`) within the `finally` suite of a `try...finally`, where control flow would jump outside the `finally` suite
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 This will result in the implicit cancellation of the active exception.
 
@@ -630,7 +630,7 @@ def foo():
 
 ### [L.4.1] ✔️ **DO** Invoke context managers through a special function when doing something other than handling resources
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -647,7 +647,7 @@ with connection.begin_transaction():
 
 ### [L.5.1] ❌ **DO NOT** rely on the implicit `return None` if a function is expected to return a value
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -664,7 +664,7 @@ def get_stock(cheese_kind):
 
 ### [L.5.2] ❌ **DO NOT** rely on the implicit `return` implictly returning `None` if a function is expected to return a value
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -684,7 +684,7 @@ def get_stock(cheese_kind):
 
 ### [L.6.1] ✔️ **DO** use `startswith` and `endswith` instead of slicing or indexing a string
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -704,7 +704,7 @@ if title.endswith("s"): ...
 
 ### [O.1.2] ✔️ **DO** Put module imports on separate lines
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 # Bad
@@ -717,7 +717,7 @@ import sys
 
 ### [O.1.2] ✔️ **DO** Put imports at the top of the file
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 Imports come _after_ module comments and docstrings and _before_ module globals and constants.
 
@@ -742,7 +742,7 @@ URL = "http://python.org"
 
 ### [O.1.3] ✔️ **DO** Group imports by standard library, third party, then first_party
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 Additionally, you should put a blank line between each group of imports.
 
@@ -762,7 +762,7 @@ import my_app.utils
 
 ### [O.1.4] ✔️ **DO** Use absolute imports
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ℹ️ An exception can be made for `__init__.py` files republishing child module declarations
 
@@ -776,7 +776,7 @@ from my_app.relationships.sibling import rivalry
 
 ### [O.1.5] ❌ **DO NOT** Use wildcard imports
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ℹ️ An exception can be made if you are overwriting an internal interface and you do not know which definitions will be overwritten
 
@@ -795,7 +795,7 @@ import ministry
 
 ### [O.2.1] ✔️ **DO** Put module level dunder names after module docstring and before import statements
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 """Lumberjack: Cuts down trees, among other things"""
@@ -815,15 +815,15 @@ import sys
 
 ### [D.1.1] ✔️ **DO** Write docstrings for all public modules, functions, classes, and methods
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008) and [PEP 257](https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008) and [PEP 257](https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring)
 
 ### [D.1.2] ✔️ **DO** Put closing `"""` on the same line for one line docstrings
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008) and [PEP 257](https://www.python.org/dev/peps/pep-0257/#one-line-docstrings)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008) and [PEP 257](https://www.python.org/dev/peps/pep-0257/#one-line-docstrings)
 
 ### [D.1.3] ✔️ **DO** Put closing `"""` on its own line for multiline docstrings
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008) and [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008) and [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
 ---
 
@@ -833,39 +833,39 @@ import sys
 
 ### [C.1.1] ✔️ **DO** Use complete sentences (with periods for multiple sentences)
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [C.1.2] ✔️ **DO** Capitalize the first word, unless it is an identifier that begins with a lower case letter
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [C.1.3] ✔️ **DO** Start comments with a `#` and a single space (unless otherwise stated)
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ## [C.2] Block Comments
 
 ### [C.2.1] ✔️ **DO** Indent block comments to the same level as the code
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [C.2.2] ✔️ **DO** Start each line of a block comment with a `#` and a single space (unless it is indented text inside the comment)
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [C.2.3] ✔️ **DO** Separate paragraphs inside a block comment by a line containing a single `#`
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ## [C.3] Inline Comments
 
 ### [C.3.1] ✔️ **CONSIDER** Using inline comments sparingly
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [C.3.2] ✔️ **DO** Separate statements and inline comments by two spaces
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
 order = [egg, sausage, bacon]  # The client doesn't want any spam
@@ -879,11 +879,11 @@ order = [egg, sausage, bacon]  # The client doesn't want any spam
 
 ### [S.1.1] ✔️ **DO** Use UTF-8 for source code
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ### [S.1.2] ❌ **DO NOT** Use an encoding declaration
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 Bad:
 
@@ -895,7 +895,7 @@ Bad:
 
 ### [S.1.3] ❌ **AVOID** Using non-ASCII characters in string literals and comments
 
-> 🐍 This rule stems from [PEP-8](https://www.python.org/dev/peps/pep-0008)
+> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ℹ️ Exceptions can be made for:
 


### PR DESCRIPTION
PEPs don't use a hyphen: https://www.python.org/dev/peps/pep-0008/ so we shouldn't either.