### PR TITLE
Prepare the styleguide for automated convention testing

### DIFF
--- a/docs/Coding-Conventions.md
+++ b/docs/Coding-Conventions.md
@@ -50,9 +50,42 @@ In all cases where a convention comes from a PEP, it will be marked as such.
 
 # [F] Formatting
 
-## [F.1] Indents
+## [F.1] Indentation and Line Length
 
-### [F.1.1] ✔️ **DO** Use 4 spaces per indentation level (never tabs)
+### [F.1.1] ✔️ **DO** Limit your lines to a maximum length of 100 characters
+
+There is no one-size-fits-all when it comes to a maximum line length. Too short and
+developers start contorting their code to fit the restriction. Too long and lines exceed
+what is visible in most common tools (code editors, diff visualizers, etc...). Additionally,
+automatic formatting can reduce the burden of maintaining a maximum line length, but can
+also be eager in enforcing it. In the end, choosing a maximum line length isn't about
+optimization, but is rather about finding a middle-ground that developers can agree on.
+
+We have chosen 100 characters because to some developers 80/88 characters is too limiting,
+and to others 110/120 is too long.
+
+```python
+# Bad
+directors = (
+    specially_trained_ecuradorian_mountain_llamas + venezuelan_red_llamas + mexican_whooping_llamas + north_chilean_guanacos
+    + reg_llama_of_brixton + battery_llamas + (terry_gilliam & terry_jones)
+)
+```
+
+```python
+# Good
+directors = (
+    specially_trained_ecuradorian_mountain_llamas
+    + venezuelan_red_llamas
+    + mexican_whooping_llamas
+    + north_chilean_guanacos
+    + reg_llama_of_brixton
+    + battery_llamas
+    + (terry_gilliam & terry_jones)
+)
+```
+
+### [F.1.2] ✔️ **DO** Use 4 spaces per indentation level (never tabs)
 
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
@@ -75,7 +108,9 @@ directors = (
     battery_llamas +
     (terry_gilliam & terry_jones)
 )
+```
 
+```python
 # Good
 directors = (
     specially_trained_ecuradorian_mountain_llamas
@@ -113,7 +148,9 @@ def visit_argument_room(duration):
     new_start = datetime.now()
     while (datetime.now() - new_start) < new_duration:
         self.argue_about_paying()
+```
 
+```python
 # Good - use blank lines to separate code into logically-related sections
 def visit_argument_room(duration):
     start = datetime.now()
@@ -130,7 +167,9 @@ def visit_argument_room(duration):
 
     while (datetime.now() - new_start) < new_duration:
         self.argue_about_paying()
+```
 
+```python
 # Best - extract logic into well-named methods
 def visit_argument_room(duration):
     exit_reason = self._argue_about("answer", duration=duration)
@@ -149,7 +188,9 @@ def visit_argument_room(duration):
 if answer == "no it isn't": accuse_contradiction()
 
 define_argument(); pay_for_more_time(); argue_about_paying()
+```
 
+```python
 # Good
 if answer == "no it isn't":
     accuse_contradiction()
@@ -168,7 +209,9 @@ argue_about_paying()
 ```python
 # Bad
 spam( ham[ 1 ], { eggs: 2 } )
+```
 
+```python
 # Good
 spam(ham[1], {eggs: 2})
 ```
@@ -180,7 +223,9 @@ spam(ham[1], {eggs: 2})
 ```python
 # Bad
 spam = (0, )
+```
 
+```python
 # Good
 spam = (0,)
 ```
@@ -200,7 +245,9 @@ ham[lower + offset:upper + offset]
 ham[1: 9], ham[1 :9], ham[1:9 :3]
 ham[lower : : upper]
 ham[ : upper]
+```
 
+```python
 # Good
 if x == 4:
     print x, y
@@ -219,7 +266,9 @@ ham[:upper]
 ```python
 # Bad
 spam (1)
+```
 
+```python
 # Good
 spam(1)
 ```
@@ -231,7 +280,9 @@ spam(1)
 ```python
 # Bad
 spam ['bacon'] = ham [index]
+```
 
+```python
 # Good
 spam['bacon'] = ham[index]
 ```
@@ -250,7 +301,9 @@ spam['bacon'] = ham[index]
 # Bad
 order =       egg&bacon
 other_order = egg&bacon&spam
+```
 
+```python
 # Good
 order = egg & bacon
 other_order = egg & bacon & spam
@@ -264,7 +317,9 @@ other_order = egg & bacon & spam
 # Bad
 order = (spam+bacon) & (sausage+spam)
 order = spam + bacon & sausage + spam
+```
 
+```python
 # Good
 order = (spam + bacon) & (sausage + spam)
 ```
@@ -277,7 +332,9 @@ order = (spam + bacon) & (sausage + spam)
 # Bad
 def argue(room, minutes = 5):
     return impl(r = room, m = minutes)
+```
 
+```python
 # Good
 def argue(room, minutes=5):
     return impl(r=room, m=minutes)
@@ -290,7 +347,9 @@ def argue(room, minutes=5):
 ```python
 # Bad
 def argue(duration: datetime.timedelta=5): ...
+```
 
+```python
 # Good
 def argue(duration: datetime.timedelta = 5): ...
 ```
@@ -304,7 +363,9 @@ def argue(duration: datetime.timedelta = 5): ...
 ```python
 # Bad
 ingredients = spam,
+```
 
+```python
 # Good
 ingredients = (spam,)
 ```
@@ -316,6 +377,7 @@ ingredients = (spam,)
 This can be helpful for minimizing diffs when future additions are made.
 
 ```python
+# Good
 feast = [
     lambs,
     sloths,
@@ -331,6 +393,7 @@ count(
     "Two!",
     "Five!",
 )
+
 
 def count(
     first_number,
@@ -358,11 +421,12 @@ order = [egg, sausage, bacon,]
 # Bad
 movie = "\"Fillings of Passion\""
 grounding = '\'O\' Level Geography'
+```
 
+```python
 # Good
 movie = '"Fillings of Passion"'
 grounding = "'O' Level Geography"
-
 ```
 
 ### [F.5.2] ✔️ **DO** Use double quotes characters for triple-quoted strings
@@ -370,6 +434,7 @@ grounding = "'O' Level Geography"
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008) as well as [PEP-257](https://www.python.org/dev/peps/pep-0257)
 
 ```python
+# Good
 notice = """We apologise for the fault in the subtitles.
 
 Those responsible have been sacked.
@@ -397,14 +462,13 @@ møøse_costumes = "Siggi Churchill"
 
 ❗️ In most situations, a _better_ name for the identifier is the solution. This rule only applies for cases where the keyword is the best name (I.e. referencing the built-in operation/element, like [`operator.and_`](https://docs.python.org/3.4/library/operator.html#operator.and_))
 
-```python
-# Acceptable
-in_
-for_
-class_
-input_
-file_
-```
+Examples:
+
+- in\_
+- for\_
+- class\_
+- input\_
+- file\_
 
 ## [N.2] Casing
 
@@ -415,10 +479,14 @@ file_
 ```python
 # Bad
 temporary_file
+```
 
-# Better
+```python
+# Good
 temp_file
+```
 
+```python
 # Best
 tempfile
 ```
@@ -437,7 +505,9 @@ tempfile
 # Bad
 class cheese_shop:
     pass
+```
 
+```python
 # Good
 class CheeseShop:
     pass
@@ -448,12 +518,16 @@ class CheeseShop:
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
+# Bad
 from typing import TypeVar
 
-# Bad
 flying_circus = TypeVar("flying_circus")
+```
 
+```python
 # Good
+from typing import TypeVar
+
 FlyingCircus = TypeVar("FlyingCircus")
 ```
 
@@ -462,6 +536,7 @@ FlyingCircus = TypeVar("FlyingCircus")
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
+# Good
 from typing import TypeVar
 
 FlyingCircus_co = TypeVar('FlyingCircus_co', covariant=True)
@@ -507,7 +582,9 @@ FlyingCircus_contra = TypeVar('FlyingCircus_contra', contravariant=True)
 ```python
 # Bad
 if cheese == None: ...
+```
 
+```python
 # Good
 if cheese is None: ...
 ```
@@ -519,7 +596,9 @@ if cheese is None: ...
 ```python
 # Bad
 if type(cheese) is type(that_cheese): ...
+```
 
+```python
 # Good
 if isinstance(cheese, Gorgonzola): ...
 ```
@@ -534,7 +613,9 @@ if isinstance(cheese, Gorgonzola): ...
 # Bad
 if len(seq): ...
 if not len(seq): ...
+```
 
+```python
 # Good
 if seq: ...
 if not seq: ...
@@ -549,7 +630,9 @@ if not seq: ...
 ```python
 # Bad
 respond = lambda: "is not"
+```
 
+```python
 # Good
 def respond():
    return "is not"
@@ -582,10 +665,14 @@ Additionally, be as specific as possible.
 ```python
 # Bad
 except: ...
+```
 
-# Better
+```python
+# Good
 except Exception: ...
+```
 
+```python
 # Best
 except ImportError: ...
 ```
@@ -602,7 +689,9 @@ try:
 except KeyError:
     # Will also catch KeyError raised by eat()
     return key_not_found(key)
+```
 
+```python
 # Good
 try:
     value = spam[key]
@@ -638,7 +727,9 @@ def foo():
 # Doesn't signify anything other than opening/closing is happening
 with connection:
     do_stuff_in_transaction(connection)
+```
 
+```python
 # Good
 with connection.begin_transaction():
     do_stuff_in_transaction(connection)
@@ -655,7 +746,9 @@ with connection.begin_transaction():
 def get_stock(cheese_kind):
     if in_stock(cheese_kind):
         return get_quantity(cheese_kind)
+```
 
+```python
 # Good
 def get_stock(cheese_kind):
     if in_stock(cheese_kind):
@@ -673,7 +766,9 @@ def get_stock(cheese_kind):
     if not in_stock(cheese_kind):
         return
     return get_quantity(cheese_kind)
+```
 
+```python
 # Good
 def get_stock(cheese_kind):
     if not in_stock(cheese_kind):
@@ -691,7 +786,9 @@ def get_stock(cheese_kind):
 # Bad
 if title[:4] == "King": ...
 if title[-1] == "s": ...
+```
 
+```python
 # Good
 if title.startswith("King"): ...
 if title.endswith("s"): ...
@@ -706,6 +803,7 @@ if title.endswith("s"): ...
 This includes setting `__all__` to the empty list if your module has no public API.
 
 ```python
+# Good
 __all__ = ["spam", "ham", "eggs"]
 ```
 
@@ -728,7 +826,9 @@ This includes packages, modules, classes, functions, attributes and other names.
 ```python
 # Bad
 import sys, os
+```
 
+```python
 # Good
 import os
 import sys
@@ -740,18 +840,16 @@ import sys
 
 Imports come _after_ module comments and docstrings and _before_ module globals and constants.
 
-Bad:
-
 ```python
+# Bad
 """Module Docstring."""
 URL = "http://python.org"
 
 import ministry
 ```
 
-Good:
-
 ```python
+# Good
 """Module Docstring."""
 
 import ministry
@@ -770,7 +868,9 @@ Additionally, you should put a blank line between each group of imports.
 import my_app.utils
 import os
 import ministry
+```
 
+```python
 # Good
 import os
 
@@ -788,7 +888,9 @@ import my_app.utils
 ```python
 # Bad
 from .sibling import rivalry
+```
 
+```python
 # Good
 from my_app.relationships.sibling import rivalry
 ```
@@ -802,10 +904,14 @@ from my_app.relationships.sibling import rivalry
 ```python
 # Bad - Pollutes the namespace
 from ministry import *
+```
 
+```python
 # Good - Doesn't pollute, but usage might still be confusing
 from ministry import silly_walk
+```
 
+```python
 # Best - Doesn't pollute and usage won't confuse
 import ministry
 ```
@@ -835,6 +941,7 @@ import cheese_shop.brie
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
+# Good
 """Lumberjack: Cuts down trees, among other things."""
 
 __all__ = ["cut_down_trees", "eat_lunch", "go_shopping"]
@@ -865,7 +972,9 @@ import sys
 '''Lumberjack: Cuts down trees, among other things.'''
 
 "Lumberjack: Cuts down trees, among other things."
+```
 
+```python
 # Good
 """Lumberjack: Cuts down trees, among other things."""
 ```
@@ -889,7 +998,9 @@ class CheeseShop(object):
         """Sell the specified type of cheese.
 
         Will throw an OutOfStockException if the specified type of cheese is out of stock."""
+```
 
+```python
 # Good
 class CheeseShop(object):
     """Finest cheese shop in the district, offering a wide variety of cheeses.
@@ -920,7 +1031,9 @@ class CheeseShop(object):
 
             Will throw an OutOfStockException if the specified type of cheese is out of stock.
         """
+```
 
+```python
 # Good
 class CheeseShop(object):
     """Finest cheese shop in the district, offering a wide variety of cheeses.
@@ -951,7 +1064,9 @@ class CheeseShop(object):
     def sell(self, type_):
 
         """Sell the specified type of cheese."""
+```
 
+```python
 # Good
 class CheeseShop(object):
     """Finest cheese shop in the district, offering a wide variety of cheeses."""
@@ -970,7 +1085,9 @@ def sell(type_):
     """Sell the specified type of cheese."""
 
     _do_transaction(type_)
+```
 
+```python
 # Good
 def sell(type_):
     """Sell the specified type of cheese."""
@@ -987,7 +1104,9 @@ class CheeseShop(object):
     """Finest cheese shop in the district, offering a wide variety of cheeses."""
     def sell(self, type_):
         pass
+```
 
+```python
 # Good
 class CheeseShop(object):
     """Finest cheese shop in the district, offering a wide variety of cheeses."""
@@ -1018,7 +1137,9 @@ def sell(type_):
     """Sell the specified type of cheese.
     Will throw an OutOfStockException if the specified type of cheese is out of stock.
     """
+```
 
+```python
 # Good
 def sell(type_):
     """Sell the specified type of cheese.
@@ -1123,6 +1244,7 @@ When documenting a subclass, mention the differences from superclass beahvior. A
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
 ```python
+# Good
 order = [egg, sausage, bacon]  # The client doesn't want any spam
 ```
 
@@ -1140,9 +1262,8 @@ order = [egg, sausage, bacon]  # The client doesn't want any spam
 
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
-Bad:
-
 ```python
+# Bad
 # -*- coding: utf-8 -*-
 
 ...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,9 @@ stat = "ni_python_styleguide._vendor.flakehell.formatters:StatFormatter"
 exclude = ["ni_python_styleguide/_vendor", ".venv", "docs"]
 show_source = true
 
+[tool.pytest.ini_options]
+addopts = "--doctest-modules --ignore-glob='ni_python_styleguide/**'"
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,13 +21,9 @@ def styleguide(request):
     """
 
     def runner(*args):
-        if args[0] == "lint":
-            # Use default formatting instead of the colored formatting
-            args = [
-                *args,
-                "--format",
-                "default",
-            ]
+        if args[0] == "lint" and "--format" not in args:
+            # Use the default formatter instead of the colored one
+            args = [*args, "--format", "default"]
 
         with pytest.raises(SystemExit) as exc_info:
             styleguide_main(["ni_python_styleguide", *map(str, args)])

--- a/tests/test_convention_doc/conftest.py
+++ b/tests/test_convention_doc/conftest.py
@@ -45,3 +45,54 @@ def subsection(request):
 )
 def rule(request):
     return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        pytest.param(codeblock, id=f"{rule.identifier}-{codeblock.descriptor}")
+        for rule in doctypes.RULES
+        for codeblock in rule.codeblocks
+    ],
+)
+def codeblock(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        pytest.param(codeblock, id=f"{rule.identifier}-{codeblock.descriptor}")
+        for rule in doctypes.RULES
+        for codeblock in rule.codeblocks
+        if codeblock.descriptor == "Bad"
+    ],
+)
+def bad_codeblock(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        pytest.param(codeblock, id=f"{rule.identifier}-{codeblock.descriptor}")
+        for rule in doctypes.RULES
+        for codeblock in rule.codeblocks
+        if codeblock.descriptor == "Good"
+    ],
+)
+def good_codeblock(request):
+    return request.param
+
+
+@pytest.fixture(
+    scope="module",
+    params=[
+        pytest.param(codeblock, id=f"{rule.identifier}-{codeblock.descriptor}")
+        for rule in doctypes.RULES
+        for codeblock in rule.codeblocks
+        if codeblock.descriptor == "Best"
+    ],
+)
+def best_codeblock(request):
+    return request.param

--- a/tests/test_convention_doc/doctypes.py
+++ b/tests/test_convention_doc/doctypes.py
@@ -58,10 +58,10 @@ class Rule(_RuleHeader):
     def error_codes(self):
         """Return the error codes this rule is enforced by if any, None otherwise."""
         match = re.search(
-            r"\n> 💻 This rule is enforced by codes? (.*?)\n", self.body_text,
+            r"\n> 💻 This rule is enforced by error codes? (.*?)\n", self.body_text,
         )
         if match:
-            return [code.strip("` ") for code in match[1].split(",")]
+            return [error_code.strip("` ") for error_code in match[1].split(",")]
         return None
 
 

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -26,7 +26,9 @@ def test_bad_codeblocks_document_lint_errors(lint_codeblock, bad_codeblock, caps
         ), 'Expected automatically enforced "bad" codeblock to cause lint error'
 
         captured = capsys.readouterr()
-        error_codes = set(code.strip("'") for code in captured.out.strip().split("\n"))
+        error_codes = set(
+            error_code.strip("'") for error_code in captured.out.strip().split("\n")
+        )
 
         assert error_codes.issubset(
             set(bad_codeblock.rule.error_codes)

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -1,0 +1,46 @@
+import pytest
+
+
+@pytest.fixture
+def lint_codeblock(styleguide, tmp_path):
+    def run_linter(codeblock, *styleguide_args):
+        test_file = tmp_path / "test.py"
+        test_file.write_text(codeblock.contents, encoding="utf-8")
+        return styleguide("lint", test_file, *styleguide_args)
+
+    return run_linter
+
+
+def test_rule_codeblock_uses_python(codeblock):
+    assert codeblock.language == "python"
+
+
+def test_rule_codeblocks_documents_bad_good_best(codeblock):
+    assert codeblock.descriptor in ("Good", "Bad", "Best")
+
+
+def test_bad_codeblocks_document_lint_errors(lint_codeblock, bad_codeblock, capsys):
+    if bad_codeblock.rule.is_automatically_enforced:
+        assert not lint_codeblock(
+            bad_codeblock, "--format", "'%(code)s'"
+        ), 'Expected automatically enforced "bad" codeblock to cause lint error'
+
+        captured = capsys.readouterr()
+        error_codes = set(code.strip("'") for code in captured.out.strip().split("\n"))
+
+        assert error_codes.issubset(
+            set(bad_codeblock.rule.error_codes)
+        ), '"Bad" codeblock caused unexpected lint error'
+    else:
+        # You can check stdout from the test results to see the lint errors
+        assert lint_codeblock(
+            bad_codeblock
+        ), '"Bad" codeblock caused a lint error, but isn\'t marked as automatically enforced'
+
+
+def test_good_codeblocks_have_no_lint_errors(lint_codeblock, good_codeblock):
+    assert lint_codeblock(good_codeblock), '"Good" codeblock caused lint error'
+
+
+def test_best_codeblocks_have_no_lint_errors(lint_codeblock, best_codeblock):
+    assert lint_codeblock(best_codeblock), '"Best" codeblock caused lint error'

--- a/tests/test_convention_doc/test_rules.py
+++ b/tests/test_convention_doc/test_rules.py
@@ -43,6 +43,8 @@ def test_rule_identifier_follows_case_convention(rule):
     assert rule_title[0] == rule_title[0].upper()
 
 
-def test_rule_has_at_most_one_codeblock(rule):
-    assert len(rule.codeblocks) <= 1
-
+def test_rule_documents_enforcement_codes(rule):
+    if rule.is_automatically_enforced:
+        assert rule.error_codes is not None
+    else:
+        assert rule.error_codes is None

--- a/tests/test_convention_doc/test_sections.py
+++ b/tests/test_convention_doc/test_sections.py
@@ -17,5 +17,4 @@ def test_section_identifiers_unique(sections):
 
 
 def test_section_identifier_follows_case_convention(section):
-    section_title = ("**".join(section.header_text.split("**")[2:])).strip()
-    assert section_title[0] == section_title[0].upper()
+    assert section.header_text[0] == section.header_text[0].upper()

--- a/tests/test_convention_doc/test_sections.py
+++ b/tests/test_convention_doc/test_sections.py
@@ -17,4 +17,5 @@ def test_section_identifiers_unique(sections):
 
 
 def test_section_identifier_follows_case_convention(section):
-    assert section.header_text[0] == section.header_text[0].upper()
+    header_text = section.header_text.lstrip()
+    assert header_text[0].isupper(), "header should start with an upper-case letter"

--- a/tests/test_convention_doc/test_subsections.py
+++ b/tests/test_convention_doc/test_subsections.py
@@ -39,4 +39,5 @@ def test_subsection_isnt_rule(subsection):
 
 
 def test_subsection_identifier_follows_case_convention(subsection):
-    assert subsection.header_text[0] == subsection.header_text[0].upper()
+    header_text = subsection.header_text.lstrip()
+    assert header_text[0].isupper(), "header should start with an upper-case letter"

--- a/tests/test_convention_doc/test_subsections.py
+++ b/tests/test_convention_doc/test_subsections.py
@@ -39,5 +39,4 @@ def test_subsection_isnt_rule(subsection):
 
 
 def test_subsection_identifier_follows_case_convention(subsection):
-    subsection_title = ("**".join(subsection.header_text.split("**")[2:])).strip()
-    assert subsection_title[0] == subsection_title[0].upper()
+    assert subsection.header_text[0] == subsection.header_text[0].upper()


### PR DESCRIPTION
This PR prepares the styleguide (both the document and the tooling) for having `pytest` enforce that our code examples in the convention are honest with regards to the tool. Overview of the changes:

- Already merged in https://github.com/ni/python-styleguide/pull/20
- Bad/Good codeblocks now split such that each codeblock is one of Bad/Good/Best
- Enforces we document which conventions are auto-enforced through the examples
- Enforces all Good/Best blocks cause no lint errors
- Enforces we document the error codes a bad codeblock represents

(An example of me testing this out with `pycodestyle` can be found on my branch: https://github.com/thejcannon/python-styleguide/blob/pycodestyle/docs/Coding-Conventions.md. Please note the link won't be valid forever as the branch will eventually be deleted)

---

I also want to outline here "the big picture" and some of _why_ I'm leaning this way, in case it has been lost to the wind.

- I want us to leverage as many lint plugins as makes sense. Tools are stronger than humans here.
- When we add a lint plugin, I want us to evaluate the impact it will have on our conventions (by also changing the conventions)
- In order to help all of us evaluate _ideally_ all the possible codes a plugin raises, an exhaustive set of examples can be produced in the form of codeblocks in conventions 

So my hope is that this will be a good way to help us achieve the above, by letting the tooling to the talking.