### PR TITLE
Flake8 black

### DIFF
--- a/docs/Coding-Conventions.md
+++ b/docs/Coding-Conventions.md
@@ -70,7 +70,9 @@ A formatter, enforced across all of our code, ensures that a person working on p
 - It is under the umbrella of the [Python Software Foundation](https://www.python.org/psf/), which is a good endorsement from the community
 - It does not modify the AST of the program :tada:
 
-### [F.1.2] ✔️ **DO** Limit your lines to a maximum length of 100 characters
+### [F.1.2] ✔️ **DO** Limit your lines to a maximum length of 100 characters 💻
+
+> 💻 This rule is enforced by error code BLK100
 
 ℹ️ This is easily managed by `black` by setting `line-length = 100` in your `pyproject.toml` under `[tool.black]` section
 
@@ -83,6 +85,16 @@ optimization, but is rather about finding a middle-ground that developers can ag
 
 We have chosen 100 characters because to some developers 80/88 characters is too limiting,
 and to others 110/120 is too long.
+
+```python
+# Bad
+line_with_101_chars = "spaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaam"
+```
+
+```python
+# Good
+line_with_99_chars = "spaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaam"
+```
 
 ## [F.2] Line Spacing
 

--- a/docs/Coding-Conventions.md
+++ b/docs/Coding-Conventions.md
@@ -35,8 +35,6 @@ Additionally rules might be suffixed with one of the below:
 
 This document serves as the single source of truth when it comes to Python coding conventions for NI code. Therefore other guides (such as the Google Python styleguide or various PEP-guides) are superseded by this one.
 
-We have consciously decided to extract conventions from existing guides, instead of simply linking to them to minimize the scattering of conventions, to mirror other language conventions, as well as to allow us to tweak the conventions where necessary.
-
 In all cases where a convention comes from a PEP, it will be marked as such.
 
 ## Guides considered
@@ -50,9 +48,31 @@ In all cases where a convention comes from a PEP, it will be marked as such.
 
 # [F] Formatting
 
-## [F.1] Indentation and Line Length
+## [F.1] General
 
-### [F.1.1] ✔️ **DO** Limit your lines to a maximum length of 100 characters
+### [F.1.1] ✔️ **DO** Use `black` to format your code 💻
+
+> 💻 This rule is enforced by error code BLK100
+
+`black`'s style is well-documented and can be found [here](https://black.readthedocs.io/en/stable/the_black_code_style.html).
+
+#### Why do we need a formatter?
+
+Honestly, there's no mechanical reason to need one. Some argue that as long as linters catch issues (bugs or style violations) then the humans can make sure the code looks readable.
+This might be true for a single project, but when you consider dozens of projects with dozens of contributors, **consistency matters**.
+A formatter, enforced across all of our code, ensures that a person working on project A can work on Project B without needing to spend time familiarizing himself/herself with different style.
+
+#### Why `black`?
+
+- `black` has virtually no configuration support:
+  - If we have to choose a formatter, choosing one with virtually no configuration is generally well received, as no one gets to argue about style
+  - Choosing a formatter with virtually no configuration means formatted code from one location looks the same as another location, without having to share/duplicate a config
+- It is under the umbrella of the [Python Software Foundation](https://www.python.org/psf/), which is a good endorsement from the community
+- It does not modify the AST of the program :tada:
+
+### [F.1.2] ✔️ **DO** Limit your lines to a maximum length of 100 characters
+
+ℹ️ This is easily managed by `black` by setting `line-length = 100` in your `pyproject.toml` under `[tool.black]` section
 
 There is no one-size-fits-all when it comes to a maximum line length. Too short and
 developers start contorting their code to fit the restriction. Too long and lines exceed
@@ -64,74 +84,9 @@ optimization, but is rather about finding a middle-ground that developers can ag
 We have chosen 100 characters because to some developers 80/88 characters is too limiting,
 and to others 110/120 is too long.
 
-```python
-# Bad
-directors = (
-    specially_trained_ecuradorian_mountain_llamas + venezuelan_red_llamas + mexican_whooping_llamas + north_chilean_guanacos
-    + reg_llama_of_brixton + battery_llamas + (terry_gilliam & terry_jones)
-)
-```
-
-```python
-# Good
-directors = (
-    specially_trained_ecuradorian_mountain_llamas
-    + venezuelan_red_llamas
-    + mexican_whooping_llamas
-    + north_chilean_guanacos
-    + reg_llama_of_brixton
-    + battery_llamas
-    + (terry_gilliam & terry_jones)
-)
-```
-
-### [F.1.2] ✔️ **DO** Use 4 spaces per indentation level (never tabs)
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
 ## [F.2] Line Spacing
 
-### [F.2.1] ✔️ **DO** Use a line break before a binary operator
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-This not only matches mathematical publications, but also results in more readable code:
-
-```python
-# Bad
-directors = (
-    specially_trained_ecuradorian_mountain_llamas +
-    venezuelan_red_llamas +
-    mexican_whooping_llamas +
-    north_chilean_guanacos +
-    reg_llama_of_brixton +
-    battery_llamas +
-    (terry_gilliam & terry_jones)
-)
-```
-
-```python
-# Good
-directors = (
-    specially_trained_ecuradorian_mountain_llamas
-    + venezuelan_red_llamas
-    + mexican_whooping_llamas
-    + north_chilean_guanacos
-    + reg_llama_of_brixton
-    + battery_llamas
-    + (terry_gilliam & terry_jones)
-)
-```
-
-### [F.2.2] ✔️ **DO** Surround top-level function and class definitions with two blank lines
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-### [F.2.3] ✔️ **DO** Surround method definitions inside a class by a single blank line
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-### [F.2.4] ✔️ **DO** Use blank lines in functions, sparingly, to indicate logical sections.
+### [F.2.1] ✔️ **DO** Use blank lines in functions, sparingly, to indicate logical sections.
 
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
@@ -177,268 +132,6 @@ def visit_argument_room(duration):
     if exit_reason == "timeout":
         new_duration = self._purchase_more_time()
         self._argue_about("purchasing", duration=new_duration)
-```
-
-### [F.2.5] ❌ **DO NOT** Put multiple statements on one line
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-if answer == "no it isn't": accuse_contradiction()
-
-define_argument(); pay_for_more_time(); argue_about_paying()
-```
-
-```python
-# Good
-if answer == "no it isn't":
-    accuse_contradiction()
-
-define_argument()
-pay_for_more_time()
-argue_about_paying()
-```
-
-## [F.3] Character Spacing
-
-### [F.3.1] ❌ **DO NOT** Use whitespace immediately inside parentheses, brackets or braces
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-spam( ham[ 1 ], { eggs: 2 } )
-```
-
-```python
-# Good
-spam(ham[1], {eggs: 2})
-```
-
-### [F.3.2] ❌ **DO NOT** Use whitespace between a trailing comma and a following close parenthesis
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-spam = (0, )
-```
-
-```python
-# Good
-spam = (0,)
-```
-
-### [F.3.3] ❌ **DO NOT** Use whitespace immediately before a comma, semicolon, or colon
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-ℹ️ An exception is made (and **must** be followed) for situations where the colon is acting like a binary operator and other operators are present. Then it **must** be surrounded by whitespace like any other operator.
-
-```python
-# Bad
-if x == 4 :
-    print x , y
-    x , y = y , x
-ham[lower + offset:upper + offset]
-ham[1: 9], ham[1 :9], ham[1:9 :3]
-ham[lower : : upper]
-ham[ : upper]
-```
-
-```python
-# Good
-if x == 4:
-    print x, y
-    x, y = y, x
-
-ham[lower + offset : upper + offset]
-ham[1:9], ham[1:9], ham[1:9:3]
-ham[lower::upper]
-ham[:upper]
-```
-
-### [F.3.4] ❌ **DO NOT** Use whitespace immediately before the open parenthesis that starts the argument list of a function call
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-spam (1)
-```
-
-```python
-# Good
-spam(1)
-```
-
-### [F.3.5] ❌ **DO NOT** Use whitespace immediately before the open parenthesis that starts an indexing or slicing
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-spam ['bacon'] = ham [index]
-```
-
-```python
-# Good
-spam['bacon'] = ham[index]
-```
-
-### [F.3.6] ❌ **DO NOT** Use trailing whitespace anywhere
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-### [F.3.7] ✔️ **DO** Surround binary operators with exactly one space on either side (unless otherwise stated)
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-ℹ️ Rules [F.3.9] and [F.3.10] specify exceptions to this rule
-
-```python
-# Bad
-order =       egg&bacon
-other_order = egg&bacon&spam
-```
-
-```python
-# Good
-order = egg & bacon
-other_order = egg & bacon & spam
-```
-
-### [F.3.8] ✔️ **CONSIDER** Surrounding expressions with parenthesis when different operators are used
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-order = (spam+bacon) & (sausage+spam)
-order = spam + bacon & sausage + spam
-```
-
-```python
-# Good
-order = (spam + bacon) & (sausage + spam)
-```
-
-### [F.3.9] ❌ **DO NOT** Surround the "`=`" with spaces when used to indicate a keyword argument, or when used to indicate a default value for an _unannotated_ function parameter
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-def argue(room, minutes = 5):
-    return impl(r = room, m = minutes)
-```
-
-```python
-# Good
-def argue(room, minutes=5):
-    return impl(r=room, m=minutes)
-```
-
-### [F.3.10] ✔️ **DO** Surround the "`=`" with spaces when used to indicate a default value for an _annotated_ function parameter
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-def argue(duration: datetime.timedelta=5): ...
-```
-
-```python
-# Good
-def argue(duration: datetime.timedelta = 5): ...
-```
-
-## [F.4] Trailing Commas
-
-### [F.4.1] ✔️ **DO** Parenthesize one-element tuples
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-ingredients = spam,
-```
-
-```python
-# Good
-ingredients = (spam,)
-```
-
-### [F.4.2] ✔️ **CONSIDER** Using redundant trailing commas in collection element and argument lists
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-This can be helpful for minimizing diffs when future additions are made.
-
-```python
-# Good
-feast = [
-    lambs,
-    sloths,
-    carp,
-    anchovies,
-    orangutans,
-    breakfast_cereals,
-    fruit_bats,
-]
-
-count(
-    "One!",
-    "Two!",
-    "Five!",
-)
-
-
-def count(
-    first_number,
-    second_number,
-    third_number,
-)
-```
-
-### [F.4.3] ❌ **DO NOT** Use a redundant trailing comma on the same line as a closing delimiter
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-order = [egg, sausage, bacon,]
-```
-
-## [F.5] Strings
-
-### [F.5.1] ✔️ **DO** Use single or double quotes characters when a string contains the other character
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
-
-```python
-# Bad
-movie = "\"Fillings of Passion\""
-grounding = '\'O\' Level Geography'
-```
-
-```python
-# Good
-movie = '"Fillings of Passion"'
-grounding = "'O' Level Geography"
-```
-
-### [F.5.2] ✔️ **DO** Use double quotes characters for triple-quoted strings
-
-> 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008) as well as [PEP-257](https://www.python.org/dev/peps/pep-0257)
-
-```python
-# Good
-notice = """We apologise for the fault in the subtitles.
-
-Those responsible have been sacked.
-"""
 ```
 
 ---
@@ -539,8 +232,8 @@ FlyingCircus = TypeVar("FlyingCircus")
 # Good
 from typing import TypeVar
 
-FlyingCircus_co = TypeVar('FlyingCircus_co', covariant=True)
-FlyingCircus_contra = TypeVar('FlyingCircus_contra', contravariant=True)
+FlyingCircus_co = TypeVar("FlyingCircus_co", covariant=True)
+FlyingCircus_contra = TypeVar("FlyingCircus_contra", contravariant=True)
 ```
 
 ### [N.2.6] ✔️ **DO** Suffix error exceptions with "Error"
@@ -581,12 +274,14 @@ FlyingCircus_contra = TypeVar('FlyingCircus_contra', contravariant=True)
 
 ```python
 # Bad
-if cheese == None: ...
+if cheese == None:
+    pass
 ```
 
 ```python
 # Good
-if cheese is None: ...
+if cheese is None:
+    pass
 ```
 
 ### [L.1.2] ✔️ **DO** Use `isinstance` instead of comparing types directly
@@ -595,12 +290,14 @@ if cheese is None: ...
 
 ```python
 # Bad
-if type(cheese) is type(that_cheese): ...
+if type(cheese) is type(that_cheese):
+    pass
 ```
 
 ```python
 # Good
-if isinstance(cheese, Gorgonzola): ...
+if isinstance(cheese, Gorgonzola):
+    pass
 ```
 
 ### [L.1.3] ✔️ **DO** Use the conversion to boolean to check for empty sequences
@@ -611,14 +308,18 @@ if isinstance(cheese, Gorgonzola): ...
 
 ```python
 # Bad
-if len(seq): ...
-if not len(seq): ...
+if len(seq):
+    pass
+if not len(seq):
+    pass
 ```
 
 ```python
 # Good
-if seq: ...
-if not seq: ...
+if seq:
+    pass
+if not seq:
+    pass
 ```
 
 ## [L.2] Lambdas
@@ -635,7 +336,7 @@ respond = lambda: "is not"
 ```python
 # Good
 def respond():
-   return "is not"
+    return "is not"
 ```
 
 ## [L.3] Exceptions
@@ -664,17 +365,26 @@ Additionally, be as specific as possible.
 
 ```python
 # Bad
-except: ...
+try:
+    pass
+except:
+    pass
 ```
 
 ```python
 # Good
-except Exception: ...
+try:
+    pass
+except Exception:
+    pass
 ```
 
 ```python
 # Best
-except ImportError: ...
+try:
+    pass
+except ImportError:
+    pass
 ```
 
 ### [L.3.4] ✔️ **DO** Limit the body of the try block to the absolute minimum amount of code necessary to cause the possible exception
@@ -784,14 +494,18 @@ def get_stock(cheese_kind):
 
 ```python
 # Bad
-if title[:4] == "King": ...
-if title[-1] == "s": ...
+if title[:4] == "King":
+    pass
+if title[-1] == "s":
+    pass
 ```
 
 ```python
 # Good
-if title.startswith("King"): ...
-if title.endswith("s"): ...
+if title.startswith("King"):
+    pass
+if title.endswith("s"):
+    pass
 ```
 
 ## [L.7] Modules
@@ -963,27 +677,11 @@ import sys
 
 ℹ️ You can document a package by documenting the module docstring of the package directory's `__init__.py`
 
-### [D.1.2] ✔️ **DO** Use triple double quotes for docstrings
-
-> 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#one-line-docstrings)
-
-```python
-# Bad
-'''Lumberjack: Cuts down trees, among other things.'''
-
-"Lumberjack: Cuts down trees, among other things."
-```
-
-```python
-# Good
-"""Lumberjack: Cuts down trees, among other things."""
-```
-
-### [D.1.3] ✔️ **DO** Put closing `"""` on the same line for one line docstrings
+### [D.1.2] ✔️ **DO** Put closing `"""` on the same line for one line docstrings
 
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008) and [PEP 257](https://www.python.org/dev/peps/pep-0257/#one-line-docstrings)
 
-### [D.1.4] ✔️ **DO** Put closing `"""` on its own line for multiline docstrings
+### [D.1.3] ✔️ **DO** Put closing `"""` on its own line for multiline docstrings
 
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008) and [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
@@ -1015,43 +713,9 @@ class CheeseShop(object):
         """
 ```
 
-### [D.1.5] ✔️ **DO** Align multiline docstring indentation with their quotes
-
-```python
-# Bad
-class CheeseShop(object):
-    """Finest cheese shop in the district, offering a wide variety of cheeses.
-
-        Cheeses are sold first-come-first-served, and can run out of stock rather quickly.
-    """
-
-    def sell(self, type_):
-        """
-            Sell the specified type of cheese.
-
-            Will throw an OutOfStockException if the specified type of cheese is out of stock.
-        """
-```
-
-```python
-# Good
-class CheeseShop(object):
-    """Finest cheese shop in the district, offering a wide variety of cheeses.
-
-    Cheeses are sold first-come-first-served, and can run out of stock rather quickly.
-    """
-
-    def sell(self, type_):
-        """
-        Sell the specified type of cheese.
-
-        Will throw an OutOfStockException if the specified type of cheese is out of stock.
-        """
-```
-
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
-### [D.1.6] ❌ **DO NOT** Put a blank line before a docstring
+### [D.1.4] ❌ **DO NOT** Put a blank line before a docstring
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
@@ -1075,7 +739,7 @@ class CheeseShop(object):
         """Sell the specified type of cheese."""
 ```
 
-### [D.1.7] ❌ **DO NOT** Put a blank line after a one line function docstring
+### [D.1.5] ❌ **DO NOT** Put a blank line after a one line function docstring
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
@@ -1094,38 +758,17 @@ def sell(type_):
     _do_transaction(type_)
 ```
 
-### [D.1.8] ✔️ **DO** Put a blank line after a class docstring
+### [D.1.6] ✔️ **DO** Use complete, grammatically correct sentences, ended with a period
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
-```python
-# Bad
-class CheeseShop(object):
-    """Finest cheese shop in the district, offering a wide variety of cheeses."""
-    def sell(self, type_):
-        pass
-```
-
-```python
-# Good
-class CheeseShop(object):
-    """Finest cheese shop in the district, offering a wide variety of cheeses."""
-
-    def sell(self, type_):
-        pass
-```
-
-### [D.1.9] ✔️ **DO** Use complete, grammatically correct sentences, ended with a period
-
-> 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
-
-### [D.1.10] ✔️ **DO** Write your docstrings as a command
+### [D.1.7] ✔️ **DO** Write your docstrings as a command
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
 E.g. "Do this", "Return that" instead of "Returns the ...".
 
-### [D.1.11] ✔️ **DO** Start multiline docstrings with a one-line summary followed by a blank line
+### [D.1.8] ✔️ **DO** Start multiline docstrings with a one-line summary followed by a blank line
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
@@ -1148,17 +791,17 @@ def sell(type_):
     """
 ```
 
-### [D.1.12] ✔️ **DO** List exported modules and subpackages in a package's docstring
+### [D.1.9] ✔️ **DO** List exported modules and subpackages in a package's docstring
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
-### [D.1.13] ✔️ **DO** List relevant exported objects (classes, functions, exceptions, etc...) in a module's docstring
+### [D.1.10] ✔️ **DO** List relevant exported objects (classes, functions, exceptions, etc...) in a module's docstring
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
 Each documented object should have a one-line summary (with less detail than the summary line of the objects' docstring)
 
-### [D.1.14] ✔️ **DO** Fully document a function in its docstring
+### [D.1.11] ✔️ **DO** Fully document a function in its docstring
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
@@ -1170,7 +813,7 @@ This includes (if applicable) the function's:
 - possible exceptions raised
 - restrictions on usage
 
-### [D.1.15] ✔️ **DO** Fully document a class in its docstring
+### [D.1.12] ✔️ **DO** Fully document a class in its docstring
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
@@ -1183,7 +826,7 @@ This includes (if applicable) the class's:
 
 It should not include the specific documentation for the constructor or methods.
 
-### [D.1.16] ✔️ **DO** Fully document a class's constructor and public methods
+### [D.1.13] ✔️ **DO** Fully document a class's constructor and public methods
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 
@@ -1192,7 +835,7 @@ These should follow the guidance on function docstrings.
 Note that the class's constructor doesn't need to document the instance variables, as that should be
 covered by the class's docstring.
 
-### [D.1.17] ✔️ **DO** Document a subclass (even if its behavior is mostly inherited)
+### [D.1.14] ✔️ **DO** Document a subclass (even if its behavior is mostly inherited)
 
 > 🐍 This rule stems from [PEP 257](https://www.python.org/dev/peps/pep-0257/#multi-line-docstrings)
 

--- a/ni_python_styleguide/__main__.py
+++ b/ni_python_styleguide/__main__.py
@@ -15,6 +15,14 @@ def main(argv=sys.argv):
                 str(pathlib.Path(__file__).parent / "flakehell_config.toml"),
             ]
         )
+
+    if args and args[0] == "lint":
+        args.extend(
+            [
+                "--black-config",
+                str(pathlib.Path(__file__).parent / "flakehell_config.toml"),
+            ]
+        )
     flakehell.entrypoint(args)
 
 

--- a/ni_python_styleguide/flakehell_config.toml
+++ b/ni_python_styleguide/flakehell_config.toml
@@ -1,4 +1,6 @@
 # (Please list things by alphabetical order)
+[tool.flakehell]
+max_line_length = 100
 
 [tool.flakehell.plugins]
 # Everything is on by default

--- a/ni_python_styleguide/flakehell_config.toml
+++ b/ni_python_styleguide/flakehell_config.toml
@@ -1,4 +1,11 @@
 # (Please list things by alphabetical order)
+
+[tool.black]
+# Projects are encouraged to configure black in their pyproject.toml, so that black can be run
+# to format the file (either directly or by editors). However, the linter will enforce that code
+# adheres to black's style with a line length of 100.
+line-length = 100
+
 [tool.flakehell]
 max_line_length = 100
 

--- a/ni_python_styleguide/flakehell_config.toml
+++ b/ni_python_styleguide/flakehell_config.toml
@@ -4,9 +4,11 @@
 # Projects are encouraged to configure black in their pyproject.toml, so that black can be run
 # to format the file (either directly or by editors). However, the linter will enforce that code
 # adheres to black's style with a line length of 100.
+# See also: https://ni.github.io/python-styleguide/#F-1-2
 line-length = 100
 
 [tool.flakehell]
+# See https://ni.github.io/python-styleguide/#F-1-2
 max_line_length = 100
 
 [tool.flakehell.plugins]

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,5 +1,13 @@
 [[package]]
 category = "main"
+description = "A small Python module for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
+name = "appdirs"
+optional = false
+python-versions = "*"
+version = "1.4.4"
+
+[[package]]
+category = "main"
 description = "An abstract syntax tree for Python with inference support."
 name = "astroid"
 optional = false
@@ -40,12 +48,55 @@ tests = ["coverage", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.i
 
 [[package]]
 category = "main"
+description = "The uncompromising code formatter."
+name = "black"
+optional = false
+python-versions = ">=3.6"
+version = "20.8b1"
+
+[package.dependencies]
+appdirs = "*"
+click = ">=7.1.2"
+mypy-extensions = ">=0.4.3"
+pathspec = ">=0.6,<1"
+regex = ">=2020.1.8"
+toml = ">=0.10.1"
+typed-ast = ">=1.4.0"
+typing-extensions = ">=3.7.4"
+
+[package.dependencies.dataclasses]
+python = "<3.7"
+version = ">=0.6"
+
+[package.extras]
+colorama = ["colorama (>=0.4.3)"]
+d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
+
+[[package]]
+category = "main"
+description = "Composable command line interface toolkit"
+name = "click"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "7.1.2"
+
+[[package]]
+category = "main"
 description = "Cross-platform colored terminal text."
 marker = "sys_platform == \"win32\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 version = "0.4.3"
+
+[[package]]
+category = "main"
+description = "A backport of the dataclasses module for Python 3.6"
+marker = "python_version < \"3.7\""
+name = "dataclasses"
+optional = false
+python-versions = "*"
+version = "0.6"
 
 [[package]]
 category = "main"
@@ -63,6 +114,18 @@ pyflakes = ">=2.2.0,<2.3.0"
 [package.dependencies.importlib-metadata]
 python = "<3.8"
 version = "*"
+
+[[package]]
+category = "main"
+description = "flake8 plugin to call black as a code style validator"
+name = "flake8-black"
+optional = false
+python-versions = "*"
+version = "0.2.1"
+
+[package.dependencies]
+black = "*"
+flake8 = ">=3.0.0"
 
 [[package]]
 category = "main"
@@ -127,6 +190,14 @@ python-versions = ">=3.5"
 version = "8.4.0"
 
 [[package]]
+category = "main"
+description = "Experimental type system extensions for programs checked with the mypy typechecker."
+name = "mypy-extensions"
+optional = false
+python-versions = "*"
+version = "0.4.3"
+
+[[package]]
 category = "dev"
 description = "Core utilities for Python packages"
 name = "packaging"
@@ -137,6 +208,14 @@ version = "20.4"
 [package.dependencies]
 pyparsing = ">=2.0.2"
 six = "*"
+
+[[package]]
+category = "main"
+description = "Utility library for gitignore style pattern matching of file paths."
+name = "pathspec"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "0.8.0"
 
 [[package]]
 category = "dev"
@@ -238,6 +317,14 @@ testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xm
 
 [[package]]
 category = "main"
+description = "Alternative regular expression module, to replace re."
+name = "regex"
+optional = false
+python-versions = "*"
+version = "2020.7.14"
+
+[[package]]
+category = "main"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
@@ -263,11 +350,18 @@ version = "0.10.1"
 [[package]]
 category = "main"
 description = "a fork of Python 2 and 3 ast modules with type comment support"
-marker = "implementation_name == \"cpython\" and python_version < \"3.8\""
 name = "typed-ast"
 optional = false
 python-versions = "*"
 version = "1.4.1"
+
+[[package]]
+category = "main"
+description = "Backported and Experimental Type Hints for Python 3.5+"
+name = "typing-extensions"
+optional = false
+python-versions = "*"
+version = "3.7.4.3"
 
 [[package]]
 category = "main"
@@ -304,11 +398,15 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "470dd7a3bf1cc9ff7985709ee594d5540bacbb1235a07f91e5b4a7612924c0d2"
+content-hash = "dd97ea6a4244d7c4e486c602015d0f28743512af4b2b6e395798d4b54e841df7"
 lock-version = "1.0"
 python-versions = "^3.6"
 
 [metadata.files]
+appdirs = [
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
+]
 astroid = [
     {file = "astroid-2.4.2-py3-none-any.whl", hash = "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"},
     {file = "astroid-2.4.2.tar.gz", hash = "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703"},
@@ -321,13 +419,28 @@ attrs = [
     {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
     {file = "attrs-19.3.0.tar.gz", hash = "sha256:f7b7ce16570fe9965acd6d30101a28f62fb4a7f9e926b3bbc9b61f8b04247e72"},
 ]
+black = [
+    {file = "black-20.8b1-py3-none-any.whl", hash = "sha256:70b62ef1527c950db59062cda342ea224d772abdf6adc58b86a45421bab20a6b"},
+    {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
+]
+click = [
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
+]
 colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
+dataclasses = [
+    {file = "dataclasses-0.6-py3-none-any.whl", hash = "sha256:454a69d788c7fda44efd71e259be79577822f5e3f53f029a22d08004e951dc9f"},
+    {file = "dataclasses-0.6.tar.gz", hash = "sha256:6988bd2b895eef432d562370bb707d540f32f7360ab13da45340101bc2307d84"},
+]
 flake8 = [
     {file = "flake8-3.8.3-py2.py3-none-any.whl", hash = "sha256:15e351d19611c887e482fb960eae4d44845013cc142d42896e9862f775d8cf5c"},
     {file = "flake8-3.8.3.tar.gz", hash = "sha256:f04b9fcbac03b0a3e58c0ab3a0ecc462e023a9faf046d57794184028123aa208"},
+]
+flake8-black = [
+    {file = "flake8-black-0.2.1.tar.gz", hash = "sha256:f26651bc10db786c03f4093414f7c9ea982ed8a244cec323c984feeffdf4c118"},
 ]
 importlib-metadata = [
     {file = "importlib_metadata-1.7.0-py2.py3-none-any.whl", hash = "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"},
@@ -372,9 +485,17 @@ more-itertools = [
     {file = "more-itertools-8.4.0.tar.gz", hash = "sha256:68c70cc7167bdf5c7c9d8f6954a7837089c6a36bf565383919bb595efb8a17e5"},
     {file = "more_itertools-8.4.0-py3-none-any.whl", hash = "sha256:b78134b2063dd214000685165d81c154522c3ee0a1c0d4d113c80361c234c5a2"},
 ]
+mypy-extensions = [
+    {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
+    {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
+]
 packaging = [
     {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
     {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+]
+pathspec = [
+    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
+    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
 ]
 pluggy = [
     {file = "pluggy-0.13.1-py2.py3-none-any.whl", hash = "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"},
@@ -407,6 +528,29 @@ pyparsing = [
 pytest = [
     {file = "pytest-6.0.1-py3-none-any.whl", hash = "sha256:8b6007800c53fdacd5a5c192203f4e531eb2a1540ad9c752e052ec0f7143dbad"},
     {file = "pytest-6.0.1.tar.gz", hash = "sha256:85228d75db9f45e06e57ef9bf4429267f81ac7c0d742cc9ed63d09886a9fe6f4"},
+]
+regex = [
+    {file = "regex-2020.7.14-cp27-cp27m-win32.whl", hash = "sha256:e46d13f38cfcbb79bfdb2964b0fe12561fe633caf964a77a5f8d4e45fe5d2ef7"},
+    {file = "regex-2020.7.14-cp27-cp27m-win_amd64.whl", hash = "sha256:6961548bba529cac7c07af2fd4d527c5b91bb8fe18995fed6044ac22b3d14644"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c50a724d136ec10d920661f1442e4a8b010a4fe5aebd65e0c2241ea41dbe93dc"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8a51f2c6d1f884e98846a0a9021ff6861bdb98457879f412fdc2b42d14494067"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9c568495e35599625f7b999774e29e8d6b01a6fb684d77dee1f56d41b11b40cd"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:51178c738d559a2d1071ce0b0f56e57eb315bcf8f7d4cf127674b533e3101f88"},
+    {file = "regex-2020.7.14-cp36-cp36m-win32.whl", hash = "sha256:9eddaafb3c48e0900690c1727fba226c4804b8e6127ea409689c3bb492d06de4"},
+    {file = "regex-2020.7.14-cp36-cp36m-win_amd64.whl", hash = "sha256:14a53646369157baa0499513f96091eb70382eb50b2c82393d17d7ec81b7b85f"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:1269fef3167bb52631ad4fa7dd27bf635d5a0790b8e6222065d42e91bede4162"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d0a5095d52b90ff38592bbdc2644f17c6d495762edf47d876049cfd2968fbccf"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:4c037fd14c5f4e308b8370b447b469ca10e69427966527edcab07f52d88388f7"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bc3d98f621898b4a9bc7fecc00513eec8f40b5b83913d74ccb445f037d58cd89"},
+    {file = "regex-2020.7.14-cp37-cp37m-win32.whl", hash = "sha256:46bac5ca10fb748d6c55843a931855e2727a7a22584f302dd9bb1506e69f83f6"},
+    {file = "regex-2020.7.14-cp37-cp37m-win_amd64.whl", hash = "sha256:0dc64ee3f33cd7899f79a8d788abfbec168410be356ed9bd30bbd3f0a23a7204"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a"},
+    {file = "regex-2020.7.14-cp38-cp38-win32.whl", hash = "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341"},
+    {file = "regex-2020.7.14-cp38-cp38-win_amd64.whl", hash = "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840"},
+    {file = "regex-2020.7.14.tar.gz", hash = "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb"},
 ]
 six = [
     {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
@@ -441,6 +585,11 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+typing-extensions = [
+    {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
+    {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
+    {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 urllib3 = [
     {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ include = ["ni_python_styleguide/flakehell_config.toml"]
 python = "^3.6"
 flake8 = "^3.8.3"
 
+black = "^20.8b1"  # Needed by flake8-black
+
 # @TODO: flakehell's dependencies.
 # Since we're vendoring flakehell, these are required here.
 pygments = "*"
@@ -19,6 +21,7 @@ toml = "*"
 urllib3 = "*"
 
 # flake8 plugins should be listed here (in alphabetical order)
+flake8-black = "^0.2.1"
 
 # Rejected flake8 plugins should be listed here (in alphabetical order)
 # Also describe why it is rejected and/or add a link
@@ -42,9 +45,13 @@ grouped = "ni_python_styleguide._vendor.flakehell.formatters:GroupedFormatter"
 json = "ni_python_styleguide._vendor.flakehell.formatters:JSONFormatter"
 stat = "ni_python_styleguide._vendor.flakehell.formatters:StatFormatter"
 
+[tool.black]
+line_length = 100
+exclude = ["ni_python_styleguide/_vendor", ".venv", "docs"]
+
 [tool.flakehell]
 exclude = ["ni_python_styleguide/_vendor", ".venv", "docs"]
-show_source = true
+show_source = false
 
 [tool.pytest.ini_options]
 addopts = "--doctest-modules --ignore-glob='ni_python_styleguide/**'"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,8 +46,8 @@ json = "ni_python_styleguide._vendor.flakehell.formatters:JSONFormatter"
 stat = "ni_python_styleguide._vendor.flakehell.formatters:StatFormatter"
 
 [tool.black]
-line_length = 100
-exclude = ["ni_python_styleguide/_vendor", ".venv", "docs"]
+line-length = 100
+force-exclude = '/ni_python_styleguide/_vendor|.venv/'
 
 [tool.flakehell]
 exclude = ["ni_python_styleguide/_vendor", ".venv", "docs"]

--- a/tests/test_convention_doc/conftest.py
+++ b/tests/test_convention_doc/conftest.py
@@ -20,9 +20,7 @@ def rules():
 
 @pytest.fixture(
     scope="module",
-    params=[
-        pytest.param(section, id=section.identifier) for section in doctypes.SECTIONS
-    ],
+    params=[pytest.param(section, id=section.identifier) for section in doctypes.SECTIONS],
 )
 def section(request):
     return request.param
@@ -31,8 +29,7 @@ def section(request):
 @pytest.fixture(
     scope="module",
     params=[
-        pytest.param(subsection, id=subsection.identifier)
-        for subsection in doctypes.SUBSECTIONS
+        pytest.param(subsection, id=subsection.identifier) for subsection in doctypes.SUBSECTIONS
     ],
 )
 def subsection(request):

--- a/tests/test_convention_doc/doctypes.py
+++ b/tests/test_convention_doc/doctypes.py
@@ -80,9 +80,7 @@ class Rule(_RuleHeader):
     @property
     def error_codes(self):
         """Return the error codes this rule is enforced by if any, None otherwise."""
-        match = re.search(
-            r"\n> 💻 This rule is enforced by error codes? (.*?)\n", self.body_text,
-        )
+        match = re.search(r"\n> 💻 This rule is enforced by error codes? (.*?)\n", self.body_text)
         if match:
             return [error_code.strip("` ") for error_code in match[1].split(",")]
         return None
@@ -98,22 +96,14 @@ class Codeblock(object):
 
 def _get_sections():
     conventions_text = (
-        pathlib.Path(__file__).absolute().parent.parent.parent
-        / "docs"
-        / "Coding-Conventions.md"
+        pathlib.Path(__file__).absolute().parent.parent.parent / "docs" / "Coding-Conventions.md"
     ).read_text(encoding="utf-8")
 
-    convention_rules_text = conventions_text[
-        conventions_text.find("<!-- Begin Auto-ID -->") :
-    ]
+    convention_rules_text = conventions_text[conventions_text.find("<!-- Begin Auto-ID -->") :]
 
     return Section.from_text(convention_rules_text)
 
 
 SECTIONS = _get_sections()
-SUBSECTIONS = list(
-    itertools.chain.from_iterable(section.subsections for section in SECTIONS)
-)
-RULES = list(
-    itertools.chain.from_iterable(subsection.rules for subsection in SUBSECTIONS)
-)
+SUBSECTIONS = list(itertools.chain.from_iterable(section.subsections for section in SECTIONS))
+RULES = list(itertools.chain.from_iterable(subsection.rules for subsection in SUBSECTIONS))

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -1,3 +1,5 @@
+import json
+
 import pytest
 
 
@@ -22,12 +24,11 @@ def test_rule_codeblocks_documents_bad_good_best(codeblock):
 def test_bad_codeblocks_document_lint_errors(lint_codeblock, bad_codeblock, capsys):
     if bad_codeblock.rule.is_automatically_enforced:
         assert not lint_codeblock(
-            bad_codeblock, "--format", "'%(code)s'"
+            bad_codeblock, "--format", "json"
         ), 'Expected automatically enforced "bad" codeblock to cause lint error'
 
-        captured = capsys.readouterr()
         error_codes = set(
-            error_code.strip("'") for error_code in captured.out.strip().split("\n")
+            json.loads(lint_error)['code'] for lint_error in capsys.readouterr().out.splitlines()
         )
 
         assert error_codes.issubset(

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -28,7 +28,7 @@ def test_bad_codeblocks_document_lint_errors(lint_codeblock, bad_codeblock, caps
         ), 'Expected automatically enforced "bad" codeblock to cause lint error'
 
         error_codes = set(
-            json.loads(lint_error)['code'] for lint_error in capsys.readouterr().out.splitlines()
+            json.loads(lint_error)["code"] for lint_error in capsys.readouterr().out.splitlines()
         )
 
         assert error_codes.issubset(


### PR DESCRIPTION
# Justification

Now that `black` has been approved as a formatting technology, we should have `ni-python-styleguide` follow suit. This involves:

- Ensuring `ni-python-styleguide`'s code adheres to `black`'s style
- Adding a convention that all code should follow `black`'s style
- Removing any conventions which `black` automatically enforces
- Adding `flake8-black` to `ni-python-styleguide`, which enforces `black`'s style at the linter level.