### PR TITLE
Fix tests by adding format param

### DIFF
--- a/ni_python_styleguide/_cli.py
+++ b/ni_python_styleguide/_cli.py
@@ -96,9 +96,10 @@ def main(ctx, verbose, quiet, config, exclude, extend_exclude):
 
 @main.command()
 # @TODO: When we're ready to encourage editor integration, add --diff flag
+@click.option("--format", type=str, help="Format errors according to the chosen formatter.")
 @click.argument("file_or_dir", nargs=-1)
 @click.pass_obj
-def lint(obj, file_or_dir):
+def lint(obj, format, file_or_dir):
     app = flake8.main.application.Application()
     filtered_list = lambda iter: list(filter(bool, iter))
     app.run(
@@ -109,6 +110,7 @@ def lint(obj, file_or_dir):
                 _qs_or_vs(obj["VERBOSITY"]),
                 f"--max-line-length={_LINE_LENGTH}",
                 f"--exclude={obj['EXCLUDE']}" if obj["EXCLUDE"] else "",
+                f"--format={format}" if format else "",
                 # Flake8 includes pyflakes, mccabe, and pep8 by default.
                 # We have yet to evaluate these, so ignore their errors for now
                 "--extend-ignore=C90,F,E,W",

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -29,6 +29,7 @@ def test_bad_codeblocks_document_lint_errors(lint_codeblock, bad_codeblock):
 
         error_codes = set(code.strip("'") for code in result.output.splitlines())
 
+        assert error_codes
         assert error_codes.issubset(
             set(bad_codeblock.rule.error_codes)
         ), '"Bad" codeblock caused unexpected lint error'

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -24,11 +24,9 @@ def test_rule_codeblocks_documents_bad_good_best(codeblock):
 def test_bad_codeblocks_document_lint_errors(lint_codeblock, bad_codeblock):
     if bad_codeblock.rule.is_automatically_enforced:
         result = lint_codeblock(bad_codeblock, "--format='%(code)s'")
-
         assert not result, result.output
 
         error_codes = set(code.strip("'") for code in result.output.splitlines())
-
         assert error_codes
         assert error_codes.issubset(
             set(bad_codeblock.rule.error_codes)

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -8,7 +8,7 @@ def lint_codeblock(styleguide, tmp_path):
     def run_linter(codeblock, *styleguide_args):
         test_file = tmp_path / "test.py"
         test_file.write_text(codeblock.contents, encoding="utf-8")
-        return styleguide("lint", test_file, *styleguide_args)
+        return styleguide("lint", *styleguide_args, test_file)
 
     return run_linter
 
@@ -21,29 +21,28 @@ def test_rule_codeblocks_documents_bad_good_best(codeblock):
     assert codeblock.descriptor in ("Good", "Bad", "Best")
 
 
-def test_bad_codeblocks_document_lint_errors(lint_codeblock, bad_codeblock, capsys):
+def test_bad_codeblocks_document_lint_errors(lint_codeblock, bad_codeblock):
     if bad_codeblock.rule.is_automatically_enforced:
-        assert not lint_codeblock(
-            bad_codeblock, "--format", "json"
-        ), 'Expected automatically enforced "bad" codeblock to cause lint error'
+        result = lint_codeblock(bad_codeblock, "--format='%(code)s'")
 
-        error_codes = set(
-            json.loads(lint_error)["code"] for lint_error in capsys.readouterr().out.splitlines()
-        )
+        assert not result, result.output
+
+        error_codes = set(code.strip("'") for code in result.output.splitlines())
 
         assert error_codes.issubset(
             set(bad_codeblock.rule.error_codes)
         ), '"Bad" codeblock caused unexpected lint error'
     else:
-        # You can check stdout from the test results to see the lint errors
-        assert lint_codeblock(
-            bad_codeblock
-        ), '"Bad" codeblock caused a lint error, but isn\'t marked as automatically enforced'
+        # "Bad" codeblock caused a lint error, but isn't marked as automatically enforced
+        result = lint_codeblock(bad_codeblock)
+        assert result, result.output
 
 
 def test_good_codeblocks_have_no_lint_errors(lint_codeblock, good_codeblock):
-    assert lint_codeblock(good_codeblock), '"Good" codeblock caused lint error'
+    result = lint_codeblock(good_codeblock)
+    assert result, result.output
 
 
 def test_best_codeblocks_have_no_lint_errors(lint_codeblock, best_codeblock):
-    assert lint_codeblock(best_codeblock), '"Best" codeblock caused lint error'
+    result = lint_codeblock(best_codeblock)
+    assert result, result.output


### PR DESCRIPTION
The tests were passing because we were asserting the command failed, and then testing that the errors the command resulted in was a subset of what we expected. Since we didn't have the format param, the errors we produced was an empty set 😢.

This is fixed by fixing the format param issue and also asserting there are some error codes in the output.