### PR TITLE
Turn on pyflakes linting

### DIFF
--- a/docs/Coding-Conventions.md
+++ b/docs/Coding-Conventions.md
@@ -27,15 +27,20 @@ This is a living document that represents our coding conventions. Rules that are
 
 Additionally rules might be suffixed with one of the below:
 
-> 💻 - The convention is automatically enforced through tooling (I.e lint error)
+> 💻 - The convention is automatically enforced by `ni-python-styleguide` (By running `ni-python-styleguide lint ...`)
 >
-> ✨ - The convention is automatically fixed through tooling
+> ✨ - The convention is automatically fixed by `ni-python-stylgeuide` (`ni-python-styleguide` command doesn't exist yet)
 
 # This vs. other guides (like PEPs)
 
 This document serves as the single source of truth when it comes to Python coding conventions for NI code. Therefore other guides (such as the Google Python styleguide or various PEP-guides) are superseded by this one.
 
 In all cases where a convention comes from a PEP, it will be marked as such.
+
+# This vs. `ni-python-styleguide`
+
+Ideally, the conventions in this document would completely match the things `ni-python-styleguide` enforces.
+However, some checks we enforce don't correspond to conventions here as they either represent specific syntax issues or logic errors, both of which we assume the Python file is free from for the purposes of this document.
 
 ## Guides considered
 
@@ -114,7 +119,7 @@ line_with_99_chars = "spaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 
 ```python
 # Bad - no spaces to form logical breaks in code
-def visit_argument_room(duration):
+def visit_argument_room(self, duration):
     start = datetime.now()
     while (datetime.now() - start) < duration:
         reply = self.argue_about_answer()
@@ -129,7 +134,7 @@ def visit_argument_room(duration):
 
 ```python
 # Good - use blank lines to separate code into logically-related sections
-def visit_argument_room(duration):
+def visit_argument_room(self, duration):
     start = datetime.now()
 
     while (datetime.now() - start) < duration:
@@ -148,7 +153,7 @@ def visit_argument_room(duration):
 
 ```python
 # Best - extract logic into well-named methods
-def visit_argument_room(duration):
+def visit_argument_room(self, duration):
     exit_reason = self._argue_about("answer", duration=duration)
 
     if exit_reason == "timeout":
@@ -225,20 +230,7 @@ class Outputs:
 
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
-```python
-# Bad
-temporary_file
-```
-
-```python
-# Good
-temp_file
-```
-
-```python
-# Best
-tempfile
-```
+E.g. `tempfile` is preferred over `temp_file` or `temporary_file`
 
 ### [N.2.2] ✔️ **DO** Use `snake_case` for function, variable, and parameter names
 
@@ -489,22 +481,24 @@ except ImportError:
 
 ```python
 # Bad
-try:
-    # Too broad!
-    return eat(spam[key])
-except KeyError:
-    # Will also catch KeyError raised by eat()
-    return key_not_found(key)
+def lunchtime():
+    try:
+        # Too broad!
+        return eat(spam[key])
+    except KeyError:
+        # Will also catch KeyError raised by eat()
+        return key_not_found(key)
 ```
 
 ```python
 # Good
-try:
-    value = spam[key]
-except KeyError:
-    return key_not_found(key)
-else:
-    return eat(value)
+def lunchtime():
+    try:
+        value = spam[key]
+    except KeyError:
+        return key_not_found(key)
+    else:
+        return eat(value)
 ```
 
 ### [L.3.5] ❌ **DO NOT** Use flow control statements (`return`/`break`/`continue`) within the `finally` suite of a `try...finally`, where control flow would jump outside the `finally` suite
@@ -615,6 +609,23 @@ This includes setting `__all__` to the empty list if your module has no public A
 ```python
 # Good
 __all__ = ["spam", "ham", "eggs"]
+
+
+def spam():
+    pass
+
+
+def ham():
+    pass
+
+
+def eggs():
+    pass
+```
+
+```python
+# Good
+__all__ = []
 ```
 
 ### [L.7.2] ✔️ **DO** Prefix internal interfaces with a single leading underscore
@@ -709,9 +720,11 @@ from .sibling import rivalry
 from my_app.relationships.sibling import rivalry
 ```
 
-### [O.1.5] ❌ **DO NOT** Use wildcard imports
+### [O.1.5] ❌ **DO NOT** Use wildcard imports 💻
 
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
+
+> 💻 This rule is enforced by error code F403
 
 ℹ️ An exception can be made if you are overwriting an internal interface and you do not know which definitions will be overwritten
 
@@ -748,9 +761,66 @@ import brie
 import cheese_shop.brie
 ```
 
+### [O.1.7] ❌ **DO NOT** Import definitions that are not used 💻
+
+> 💻 This rule is enforced by error code F401
+
+```python
+# Bad
+import os  # Assuming os is never used
+```
+
 ## [O.2] Declarations
 
-### [O.2.1] ✔️ **DO** Put module level dunder names after module docstring and before import statements
+### [O.2.1] ❌ **DO NOT** Redefine or "shadow" declarations 💻
+
+> 💻 This rule is enforced by error codes F402, F811
+
+```python
+# Bad - Will produce F402
+import cheese
+
+for cheese in ["Caithness", "Sage Derby", "Gorgonzola"]:
+    pass
+```
+
+```python
+# Bad - Will produce F811
+def eat_lunch():
+    pass
+
+
+def eat_lunch():
+    pass
+```
+
+### [O.2.2] ❌ **DO NOT** Declare unused variables 💻
+
+> 💻 This rule is enforced by error codes F841
+
+If a variable must exist but won't be used it is permissible to name the variable a single underscore `_`.
+
+```python
+# Bad
+def purchase_cheese():
+    cheese = "Gorgonzola"
+```
+
+```python
+# Bad
+def feast_upon():
+    first, *skip_a_bit, last = ["lambs", "sloths", "breakfast cereals", "fruit bats"]
+    return [first, last]
+```
+
+```python
+# Good
+def feast_upon():
+    first, *_, last = ["lambs", "sloths", "breakfast cereals", "fruit bats"]
+    return [first, last]
+```
+
+### [O.2.3] ✔️ **DO** Put module level dunder names after module docstring and before import statements
 
 > 🐍 This rule stems from [PEP 8](https://www.python.org/dev/peps/pep-0008)
 
@@ -763,6 +833,18 @@ __version__ = "0.1"
 
 import os
 import sys
+
+
+def cut_down_trees():
+    pass
+
+
+def eat_lunch():
+    pass
+
+
+def go_shopping():
+    pass
 ```
 
 ---
@@ -845,17 +927,17 @@ class CheeseShop(object):
 
 ```python
 # Bad
-def sell(type_):
+def sell(self, type_):
     """Sell the specified type of cheese."""
 
-    _do_transaction(type_)
+    self._do_transaction(type_)
 ```
 
 ```python
 # Good
-def sell(type_):
+def sell(self, type_):
     """Sell the specified type of cheese."""
-    _do_transaction(type_)
+    self._do_transaction(type_)
 ```
 
 ### [D.1.6] ✔️ **DO** Use complete, grammatically correct sentences, ended with a period
@@ -988,7 +1070,7 @@ When documenting a subclass, mention the differences from superclass beahvior. A
 
 ```python
 # Good
-order = [egg, sausage, bacon]  # The client doesn't want any spam
+order = ["egg", "sausage", "bacon"]  # The client doesn't want any spam
 ```
 
 ---

--- a/ni_python_styleguide/__main__.py
+++ b/ni_python_styleguide/__main__.py
@@ -1,5 +1,3 @@
-import sys
-
 from ni_python_styleguide._cli import main
 
 

--- a/ni_python_styleguide/_cli.py
+++ b/ni_python_styleguide/_cli.py
@@ -94,15 +94,21 @@ def main(ctx, verbose, quiet, config, exclude, extend_exclude):
 @main.command()
 # @TODO: When we're ready to encourage editor integration, add --diff flag
 @click.option("--format", type=str, help="Format errors according to the chosen formatter.")
+@click.option(
+    "--extend-ignore",
+    type=str,
+    help="Comma-separated list of errors and warnings to ignore (or skip)",
+)
 @click.argument("file_or_dir", nargs=-1)
 @click.pass_obj
-def lint(obj, format, file_or_dir):
+def lint(obj, format, extend_ignore, file_or_dir):
     app = flake8.main.application.Application()
     args = [
         _qs_or_vs(obj["VERBOSITY"]),
         f"--config={(pathlib.Path(__file__).parent / 'config.ini').resolve()}",
         f"--exclude={obj['EXCLUDE']}" if obj["EXCLUDE"] else "",
         f"--format={format}" if format else "",
+        f"--extend-ignore={extend_ignore}" if extend_ignore else "",
         # The only way to configure flake8-black's line length is through a pyproject.toml's
         # [tool.black] setting (which makes sense if you think about it)
         # So we need to give it one

--- a/ni_python_styleguide/config.ini
+++ b/ni_python_styleguide/config.ini
@@ -34,6 +34,37 @@ ignore =
     # W6 - Deprecation warning
     W6
 
-# Flake8 includes pyflakes and mccabe by default.
-# We have yet to evaluate these, so ignore their errors for now
-extend-ignore=C90,F
+    # pyflakes
+    # Ignoring string formatting related checks (until we decide on _one_ string formatting way)
+    # (Check out flake8-sfs)
+    F501
+    F502
+    F503
+    F504
+    F505
+    F506
+    F507
+    F508
+    F509
+    F522
+    F523
+    F524
+    F525
+    F541
+    # ContinueInFinally: was a SyntaxError before Python 3.8 and is "valid" in 3.8+
+    # (This is still bad behavior but also for "break" and "return", we should evaluate
+    # flake8-bugbear's B012 error)
+    F703
+    # ReturnWithArgsInsideGenerator: No longer invalid after Python 3.3
+    F705
+    # ForwardAnnotationSyntaxError: No longer invalid after Python 3.6
+    F722
+    # CommentAnnotationSyntaxError: Should be caught by mypy (convention to come!)
+    F723
+    # RedefinedInListComp: No longer applicable in Python 3+
+    F812
+
+
+# Flake8 includes mccabe by default.
+# We have yet to evaluate it, so ignore the errors for now
+extend-ignore=C90

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -1,5 +1,3 @@
-import json
-
 import pytest
 
 

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -5,7 +5,24 @@ import pytest
 
 @pytest.fixture
 def lint_codeblock(styleguide, tmp_path):
-    def run_linter(codeblock, *styleguide_args):
+    def run_linter(
+        codeblock,
+        *styleguide_args,
+        # We ignore unused import warnings as most of the codeblocks which produce this warning
+        # are just demonstrations of bad/good imports. Adding usage of the imports would add
+        # code to trivial examples, detracting from the interesting lines.
+        ignore_unused_imports=True,
+    ):
+
+        extend_ignore = [
+            # Undefined named. Defining all the names in each example would detract from the
+            # interesting lines.
+            "F821",
+        ]
+        if ignore_unused_imports:
+            extend_ignore.append("F401")
+        styleguide_args += ("--extend-ignore", ",".join(extend_ignore))
+
         test_file = tmp_path / "test.py"
         test_file.write_text(codeblock.contents, encoding="utf-8")
         return styleguide("lint", *styleguide_args, test_file)
@@ -23,7 +40,13 @@ def test_rule_codeblocks_documents_bad_good_best(codeblock):
 
 def test_bad_codeblocks_document_lint_errors(lint_codeblock, bad_codeblock):
     if bad_codeblock.rule.is_automatically_enforced:
-        result = lint_codeblock(bad_codeblock, "--format='%(code)s'")
+        result = lint_codeblock(
+            bad_codeblock,
+            "--format='%(code)s'",
+            ignore_unused_imports=(
+                "Import definitions that are not used" not in bad_codeblock.rule.header_text
+            ),
+        )
         assert not result, result.output
 
         error_codes = set(code.strip("'") for code in result.output.splitlines())

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -41,9 +41,7 @@ def test_bad_codeblocks_document_lint_errors(lint_codeblock, bad_codeblock):
         result = lint_codeblock(
             bad_codeblock,
             "--format='%(code)s'",
-            ignore_unused_imports=(
-                "Import definitions that are not used" not in bad_codeblock.rule.header_text
-            ),
+            ignore_unused_imports=("F401" not in bad_codeblock.rule.error_codes),
         )
         assert not result, result.output
 

--- a/tests/test_convention_doc/test_codeblocks.py
+++ b/tests/test_convention_doc/test_codeblocks.py
@@ -13,7 +13,7 @@ def lint_codeblock(styleguide, tmp_path):
     ):
 
         extend_ignore = [
-            # Undefined named. Defining all the names in each example would detract from the
+            # Undefined name. Defining all the names in each example would detract from the
             # interesting lines.
             "F821",
         ]


### PR DESCRIPTION
This PR enables certain `pyflakes` checks with related changes.

Note the following checks are still "on" in the tool but not called out in the convention:

## Simple logic errors:

### F601 - MultiValueRepeatedKeyLiteral
```python
{'a': 1, 'a': 2}
```

### F602 - MultiValueRepeatedKeyVariable
```python
a = 1
{a: 1, a: 2}
```

### F631 - AssertTuple ("An assert of a non-empty tuple is always True")
```python
>>> assert (False, )
```

### F633 - InvalidPrintSyntax
```python
>>> print >>sys.stderr, "Hello"
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
TypeError: unsupported operand type(s) for >>: 'builtin_function_or_method' and '_io.TextIOWrapper'. Did you mean "print(<message>, file=<output_stream>)"?
```

### F634 - IfTuple ("Booleanizing a non-empty tuple always is True")
```python
>>> if (False,):
...    print("F")
...
F
```

### F821 - UndefinedName (Just one example, use your imagination)
```python
>>> class foo:
...     foo
...
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "<stdin>", line 2, in foo
NameError: name 'foo' is not defined
```

### F822 - UndefinedExport 
```python
__all__ = ["a"]
# But 'a' doesn't exist!
```

### F823 - UndefinedLocal
```python
>>> a = 1
>>> def fun():
...     a
...     a = 2
...     return a
...
>>> fun()
Traceback (most recent call last):
File "<stdin>", line 1, in <module>
File "<stdin>", line 2, in fun
UnboundLocalError: local variable 'a' referenced before assignment
```

### F901 - RaiseNotImplemented

('raise NotImplemented' should be 'raise NotImplementedError')

## Syntax Error Checks:

### F404 - LateFutureImport
```python
>>> import os
>>> from __future__ import print_statement
File "<stdin>", line 1
SyntaxError: future feature print_statement is not defined
```

### F406 - ImportStarNotPermitted
```python
>>> def a():
...     from os import *
...
File "<stdin>", line 1
SyntaxError: import * only allowed at module level
```

### F407 - FutureFeatureNotDefined
```python
>>> from __future__ import foobar
File "<stdin>", line 1
SyntaxError: future feature foobar is not defined
```

### F621 - TooManyExpressionsInStarredAssignment
```python
>>> a0, a1, ..., a255, *rest = range(1<<8 + 1)
File "<stdin>", line 1
SyntaxError: too many expressions in star-unpacking assignment
```

### F622 - TwoStarredExpressions
```python
>>> a, *b, *c = range(10)
File "<stdin>", line 1
SyntaxError: two starred expressions in assignment
```

### F701 - BreakOutsideLoop
```python
>>> break
File "<stdin>", line 1
SyntaxError: 'break' outside loop
```

### F702 - ContinueOutsideLoop
```python
>>> continue
File "<stdin>", line 1
SyntaxError: 'continue' not properly in loop
```

### F704 - YieldOutsideFunction
```python
>>> yield 4
File "<stdin>", line 1
SyntaxError: 'yield' outside function
```

### F706 - ReturnOutsideFunction
```python
>>> return
File "<stdin>", line 1
SyntaxError: 'return' outside function
```

### F707 - DefaultExceptNotLast
```python
>>> try:
...     pass
... except:
...     pass
... except ValueError:
...     pass
...
File "<stdin>", line 2
SyntaxError: default 'except:' must be last
```

### F721 - DoctestSyntaxError (no example, use your imagination)

### F831 - DuplicateArgument
```python
>>> def foo(bar, bar): pass
...
File "<stdin>", line 1
SyntaxError: duplicate argument 'bar' in function definition
```

## Syntax Warning Checks

### F632 - IsLiteral
```python
>>> f = 'foo'
>>> f is 'foo'
<stdin>:1: SyntaxWarning: "is" with a literal. Did you mean "=="?
True
```