### PR TITLE
Post tagging release workflow

### DIFF
--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -30,6 +30,27 @@ jobs:
         with:
           poetry-version: 1.0.0
 
+      # @TODO: This is a workaround for there not being a way to check the lock file
+      #   See: https://github.com/python-poetry/poetry/issues/453
+      #   NOTE: This isn't ideal as it using the system Python and dirtying the system
+      #     Python libraries.
+      - name: Check for lock changes
+        run: |
+          PYTHONPATH="${PYTHONPATH}:${HOME}/.poetry/lib" \
+          python -c "from poetry.factory import Factory; \
+            locker = Factory().create_poetry('.').locker; \
+            exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \
+            && echo 'OK'
+
+      - name: Install the Package
+        run: poetry install
+
+      - name: Lint the Code
+        run: poetry run ni-python-styleguide lint
+
+      - name: Run tests
+        run: poetry run pytest -v
+
       # If the version is 0.1.0-alpha.0, this will set the version to 0.1.0
       - name: Promote package version to release
         run: |

--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -26,11 +26,9 @@ jobs:
           key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
           restore-keys: ${{ runner.os }}-poetry-
 
-      - name: Install Poetry
-        run: |
-          curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
-          python get-poetry.py -y
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+      - uses: Gr1N/setup-poetry@v4
+        with:
+          poetry-version: 1.0.0
 
       # If the version is 0.1.0-alpha.0, this will set the version to 0.1.0
       - name: Promote package version to release

--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -1,0 +1,62 @@
+name: Publish Package
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish_package:
+    name: Publish Package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.release.target_commitish }} # This is the branch the release was created from. Normally main/master, but can be a dev branch
+          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
+          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.6
+
+      - name: Set up Poetry cache for Python dependencies
+        uses: actions/cache@v2
+        with:
+          path: ~/.cache/pypoetry
+          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
+          restore-keys: ${{ runner.os }}-poetry-
+
+      - name: Install Poetry
+        run: |
+          curl -fsS -o get-poetry.py https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py
+          python get-poetry.py -y
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+
+      # If the version is 0.1.0-alpha.0, this will set the version to 0.1.0
+      - name: Promote package version to release
+        run: |
+          poetry version patch
+
+      - name: Build Python package and publish to PyPI
+        if: ${{ github.event.release.target_commitish == 'master' }}
+        run: |
+          poetry build
+
+      - name: Bump poetry version to next alpha version
+        run: |
+          poetry version prepatch
+
+      - name: Commit files
+        if: ${{ github.event.release.target_commitish == 'master' }}
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git pull --tags -f
+          git commit -m "Bump package version" -a
+
+      - name: Push changes
+        if: ${{ github.event.release.target_commitish == 'master' }}
+        uses: ad-m/github-push-action@master
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ github.event.release.target_commitish }}

--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build Python package and publish to PyPI
         if: ${{ github.event.release.target_commitish == 'master' }}
         run: |
-          poetry build
+          poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN}}
 
       - name: Bump poetry version to next alpha version
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,8 @@
 [tool.poetry]
 name = "ni-python-styleguide"
+# The -alpha.0 here denotes a source based version
+# This is removed when released through the Publish-Package.yml GitHub action
+# Official PyPI releases follow Major.Minor.Patch
 version = "0.1.0-alpha.0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ni-python-styleguide"
-version = "0.1.0"
+version = "0.1.0-alpha.0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
 license = "MIT"


### PR DESCRIPTION
This is an alternate workflow for: https://github.com/ni/python-styleguide/pull/31

In this workflow, the package version in the `pyproject.toml` file will always be set to `[version]-alpha`. 
The version in source is the next version that will be released.

When we are ready to release, we will use the [GitHub Release](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/managing-releases-in-a-repository) UI to created a tagged release of the version currently in source, with a `v` prepended (which is just a GitHub standard).

So if we have `0.1.0-alpha` in source, we create a release for `v0.1.0`.

We probably want to create a draft release and have some manual step of reviewing everything to make sure the tag version matches the source version, but it's not necessary for the PyPI versioned package since that only looks at the `pyproject.toml` version.

### The Release workflow will do the following main steps:
1. Checkout the branch that the release was created for (by default, the checkout step would try to checkout the tagged branch created, which we don't want.).
1. Setup Python, setup Poetry Cache, install Poetry.
1. Use `poetry version patch` to update the version from `[version]-alpha` to `[version]` (i.e. `0.1.0-alpha` -> `0.1.0`).
1. Publish the package to PyPI.
1. Use `poetry version prepatch` to update the version from `[version]` to `[version+minorIncrement]-alpha` (i.e. `0.1.0` -> `0.1.1-alpha`).
1. Commit and submit the version bump to the branch the release was created for.
