### PR TITLE
upgrade kramdown to at least 2.3.0

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -13,3 +13,6 @@ end
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.1", :platforms => [:mingw, :x64_mingw, :mswin]
+
+# security upgrade https://github.com/advisories/GHSA-mqm2-cgpr-p4m6
+gem "kramdown", ">= 2.3.0"


### PR DESCRIPTION
I've been receiving weekly emails from Dependabot alerts that we should upgrade this - doc: https://github.com/advisories/GHSA-mqm2-cgpr-p4m6