### PR TITLE
Bump the package version to 0.1.1-alpha

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ni-python-styleguide"
 # The -alpha.0 here denotes a source based version
 # This is removed when released through the Publish-Package.yml GitHub action
 # Official PyPI releases follow Major.Minor.Patch
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
 license = "MIT"


### PR DESCRIPTION
When testing out the Poetry publish, I accidentally pushed the 0.1.0 version to PyPI. Unfortunately, even if you delete a release on PyPI, it is still indexed and you cannot overwrite it.

To get around this, we'll just have to bump the version and push a new package.