### PR TITLE
Use admin PAT to bypass checks when bumping Poetry version

### DIFF
--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -49,7 +49,6 @@ jobs:
         run: poetry run ni-python-styleguide lint
 
       - name: Run tests
-
         run: poetry run pytest -v
 
       # If the version is 0.1.0-alpha.0, this will set the version to 0.1.0

--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -67,7 +67,6 @@ jobs:
           poetry version prepatch
 
       - name: Commit files
-        if: ${{ github.event.release.target_commitish == 'master' }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -75,7 +74,6 @@ jobs:
           git commit -m "Bump package version" -a
 
       - name: Push changes
-        if: ${{ github.event.release.target_commitish == 'master' }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.ADMIN_PAT }}

--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -30,43 +30,44 @@ jobs:
         with:
           poetry-version: 1.0.0
 
-      # # @TODO: This is a workaround for there not being a way to check the lock file
-      # #   See: https://github.com/python-poetry/poetry/issues/453
-      # #   NOTE: This isn't ideal as it using the system Python and dirtying the system
-      # #     Python libraries.
-      # - name: Check for lock changes
-      #   run: |
-      #     PYTHONPATH="${PYTHONPATH}:${HOME}/.poetry/lib" \
-      #     python -c "from poetry.factory import Factory; \
-      #       locker = Factory().create_poetry('.').locker; \
-      #       exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \
-      #       && echo 'OK'
+      # @TODO: This is a workaround for there not being a way to check the lock file
+      #   See: https://github.com/python-poetry/poetry/issues/453
+      #   NOTE: This isn't ideal as it using the system Python and dirtying the system
+      #     Python libraries.
+      - name: Check for lock changes
+        run: |
+          PYTHONPATH="${PYTHONPATH}:${HOME}/.poetry/lib" \
+          python -c "from poetry.factory import Factory; \
+            locker = Factory().create_poetry('.').locker; \
+            exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \
+            && echo 'OK'
 
-      # - name: Install the Package
-      #   run: poetry install
+      - name: Install the Package
+        run: poetry install
 
-      # - name: Lint the Code
-      #   run: poetry run ni-python-styleguide lint
+      - name: Lint the Code
+        run: poetry run ni-python-styleguide lint
 
-      # - name: Run tests
+      - name: Run tests
 
-      #   run: poetry run pytest -v
+        run: poetry run pytest -v
 
       # If the version is 0.1.0-alpha.0, this will set the version to 0.1.0
       - name: Promote package version to release
         run: |
           poetry version patch
 
-      # - name: Build Python package and publish to PyPI
-      #   if: ${{ github.event.release.target_commitish == 'master' }}
-      #   run: |
-      #     poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN}}
+      - name: Build Python package and publish to PyPI
+        if: ${{ github.event.release.target_commitish == 'master' }}
+        run: |
+          poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN}}
 
       - name: Bump poetry version to next alpha version
         run: |
           poetry version prepatch
 
       - name: Commit files
+        if: ${{ github.event.release.target_commitish == 'master' }}
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
@@ -74,6 +75,7 @@ jobs:
           git commit -m "Bump package version" -a
 
       - name: Push changes
+        if: ${{ github.event.release.target_commitish == 'master' }}
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.ADMIN_PAT }}

--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -30,36 +30,37 @@ jobs:
         with:
           poetry-version: 1.0.0
 
-      # @TODO: This is a workaround for there not being a way to check the lock file
-      #   See: https://github.com/python-poetry/poetry/issues/453
-      #   NOTE: This isn't ideal as it using the system Python and dirtying the system
-      #     Python libraries.
-      - name: Check for lock changes
-        run: |
-          PYTHONPATH="${PYTHONPATH}:${HOME}/.poetry/lib" \
-          python -c "from poetry.factory import Factory; \
-            locker = Factory().create_poetry('.').locker; \
-            exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \
-            && echo 'OK'
+      # # @TODO: This is a workaround for there not being a way to check the lock file
+      # #   See: https://github.com/python-poetry/poetry/issues/453
+      # #   NOTE: This isn't ideal as it using the system Python and dirtying the system
+      # #     Python libraries.
+      # - name: Check for lock changes
+      #   run: |
+      #     PYTHONPATH="${PYTHONPATH}:${HOME}/.poetry/lib" \
+      #     python -c "from poetry.factory import Factory; \
+      #       locker = Factory().create_poetry('.').locker; \
+      #       exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \
+      #       && echo 'OK'
 
-      - name: Install the Package
-        run: poetry install
+      # - name: Install the Package
+      #   run: poetry install
 
-      - name: Lint the Code
-        run: poetry run ni-python-styleguide lint
+      # - name: Lint the Code
+      #   run: poetry run ni-python-styleguide lint
 
-      - name: Run tests
-        run: poetry run pytest -v
+      # - name: Run tests
+
+      #   run: poetry run pytest -v
 
       # If the version is 0.1.0-alpha.0, this will set the version to 0.1.0
       - name: Promote package version to release
         run: |
           poetry version patch
 
-      - name: Build Python package and publish to PyPI
-        if: ${{ github.event.release.target_commitish == 'master' }}
-        run: |
-          poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN}}
+      # - name: Build Python package and publish to PyPI
+      #   if: ${{ github.event.release.target_commitish == 'master' }}
+      #   run: |
+      #     poetry publish --build --username __token__ --password ${{ secrets.PYPI_TOKEN}}
 
       - name: Bump poetry version to next alpha version
         run: |
@@ -77,5 +78,5 @@ jobs:
         if: ${{ github.event.release.target_commitish == 'master' }}
         uses: ad-m/github-push-action@master
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.ADMIN_PAT }}
           branch: ${{ github.event.release.target_commitish }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ni-python-styleguide"
 # The -alpha.0 here denotes a source based version
 # This is removed when released through the Publish-Package.yml GitHub action
 # Official PyPI releases follow Major.Minor.Patch
-version = "0.1.1-alpha.0"
+version = "0.1.2-alpha.0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ni-python-styleguide"
 # The -alpha.0 here denotes a source based version
 # This is removed when released through the Publish-Package.yml GitHub action
 # Official PyPI releases follow Major.Minor.Patch
-version = "0.1.0-alpha.0"
+version = "0.1.1-alpha.0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
 license = "MIT"


### PR DESCRIPTION
The workflow to increment the Poetry version [isn't working](https://github.com/ni/python-styleguide/runs/1658003895?check_suite_focus=true) because the branch has protections requiring reviewers to approve commits before they're submitted (usually through PR).

Apparently, this is a [known issue](https://github.com/ad-m/github-push-action/issues/36).
This is by design https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/5

Some workarounds are:
1. (This PR) Create a PAT from an admin account that is exempted from these protections.
2. Create a workflow that bumps the Poetry version and creates a PR. Reviewers will need to review and push the changes through.

I'm opting for 1 since I think we would want this process automated.

Some disclaimers:
Exposing an admin PAT is somewhat of a vulnerability since any of our workflows can use it. I think it is okay in this case because to submit a workflow, it would need to go through the review process and should be something we can catch.

Also, I'm including the Poetry version bump to get us in line with the current PyPI release since this failed in the previous workflow