### PR TITLE
add readme and project links to package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ version = "0.1.4-alpha.0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well
-homepage = "https://ni.github.io/python-styleguide/"
 repository = "https://github.com/ni/python-styleguide"
 license = "MIT"
 include = ["ni_python_styleguide/config.toml"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ name = "ni-python-styleguide"
 version = "0.1.4-alpha.0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
+readme = "README.md" # apply the repo readme to the package as well
+homepage = "https://ni.github.io/python-styleguide/"
+repository = "https://github.com/ni/python-styleguide"
 license = "MIT"
 include = ["ni_python_styleguide/config.toml"]
 


### PR DESCRIPTION
This should cause our existing readme to be used on https://pypi.org/project/ni-python-styleguide/ - based on the docs: https://python-poetry.org/docs/pyproject/#readme

Also adding "homepage" as the GH-pages site and "repository" as the base repo links