### PR TITLE
change links to fully qualified

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 ---
 
-<!-- @TODO: We should show you some stinkin' badges -->
+[![PyPI version](https://badge.fury.io/py/ni-python-styleguide.svg)](https://badge.fury.io/py/ni-python-styleguide) ![Publish Package](https://github.com/ni/python-styleguide/workflows/Publish%20Package/badge.svg) [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 
 Welcome to NI's internal and external Python conventions and enforcement tooling.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NI Python Style Guide
 
-![logo](docs/logo.svg)
+![logo](https://raw.githubusercontent.com/ni/python-styleguide/main/docs/logo.svg)
 
 ---
 
@@ -12,7 +12,7 @@ Welcome to NI's internal and external Python conventions and enforcement tooling
 
 Our written conventions can be found at https://ni.github.io/python-styleguide/.
 
-Their source is in [docs/Coding-Conventions.md](docs/Coding-Conventions.md).
+Their source is in [docs/Coding-Conventions.md](https://github.com/ni/python-styleguide/tree/main/docs/Coding-Conventions.md).
 
 NOTE: Using the GitHub Pages link is preferable to a GitHub `/blob` link.
 


### PR DESCRIPTION
we got the readme, but the image and link to docs source were broken: https://pypi.org/project/ni-python-styleguide/0.1.4/

changing to fully qualified so they should work correctly both on Github and on Pypi