### PR TITLE
Add hacking to rejected plugins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ pep8-naming = "^0.11.1"
 
 # Rejected flake8 plugins should be listed here (in alphabetical order)
 # Also describe why it is rejected and/or add a link
+# hacking: Most rules are either covered by other plugins or would be turned off.
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.0.1"


### PR DESCRIPTION
Going through the list of errors they issue: https://docs.openstack.org/hacking/latest/user/hacking.html

Most are already covered by existing plugins or will likely be covered by future plugins, so the value add just isn't there.
