### PR TITLE
Reject flake8-commas

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ pep8-naming = "^0.11.1"
 
 # Rejected flake8 plugins should be listed here (in alphabetical order)
 # Also describe why it is rejected and/or add a link
+# flake8-commas: Already handled by flake8-black
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.0.1"


### PR DESCRIPTION
This plugin is all about trailing commas, which `black` already handles.: https://github.com/PyCQA/flake8-commas/