### PR TITLE
Update pipeline templates

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -11,42 +11,60 @@ on:
       - docs/Coding-Conventions.md
       - .github/workflows/PR.yml
 
+env:
+  POETRY_VERSION: 1.1.6
+
 jobs:
-  pr:
+  checks:
+    runs-on: ubuntu-latest
+    env:
+      PYTHON_VERSION: 3.9  # Use latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ env.PYTHON_VERSION }}
+      - uses: Gr1N/setup-poetry@v4
+        with:
+          poetry-version: ${{ env.POETRY_VERSION }}
+      # @TODO: This is a workaround for there not being a way to check the lock file
+      #   See: https://github.com/python-poetry/poetry/issues/453
+      - name: Check for lock changes
+        run: |
+          PYTHONPATH="${PYTHONPATH}:${HOME}/.poetry/lib:${HOME}/.poetry/lib/poetry/_vendor/py${{ env.PYTHON_VERSION }}" \
+          python -c "from poetry.factory import Factory; \
+            locker = Factory().create_poetry('.').locker; \
+            exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \
+            && echo 'OK'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
+      - name: Install the Package
+        run: poetry install -vvv
+      - name: Lint the Code
+        run: poetry run ni-python-styleguide lint
+
+  tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v2
-
-      - uses: actions/setup-python@v1
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 
       - uses: Gr1N/setup-poetry@v4
         with:
-          poetry-version: 1.0.0
-
-      # @TODO: This is a workaround for there not being a way to check the lock file
-      #   See: https://github.com/python-poetry/poetry/issues/453
-      #   NOTE: This isn't ideal as it using the system Python and dirtying the system
-      #     Python libraries.
-      - name: Check for lock changes
-        run: |
-          pip install poetry==1.0
-          python -c "from poetry.factory import Factory; \
-            locker = Factory().create_poetry('.').locker; \
-            exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \
-            && echo 'OK'
-        shell: bash
-
+          poetry-version: ${{ env.POETRY_VERSION }}
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
       - name: Install the Package
-        run: poetry install
-
-      - name: Lint the Code
-        run: poetry run ni-python-styleguide lint
-
+        run: poetry install -vvv
       - name: Run tests
         run: poetry run pytest -v

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -65,6 +65,6 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
       - name: Install the Package
-        run: poetry install -vvv
+        run: poetry install
       - name: Run tests
         run: poetry run pytest -v

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -4,6 +4,11 @@ on:
   release:
     types: [released]
 
+env:
+  # Versions are also listed in PR.yml
+  POETRY_VERSION: 1.1.6
+  PYTHON_VERSION: 3.9  # Use latest
+
 jobs:
   publish_package:
     name: Publish Package
@@ -17,34 +22,25 @@ jobs:
 
       - uses: actions/setup-python@v2
         with:
-          python-version: 3.6
-
-      - name: Set up Poetry cache for Python dependencies
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pypoetry
-          key: ${{ runner.os }}-poetry-${{ hashFiles('**/poetry.lock') }}
-          restore-keys: ${{ runner.os }}-poetry-
-
+          python-version: ${{ env.PYTHON_VERSION }}
       - uses: Gr1N/setup-poetry@v4
         with:
-          poetry-version: 1.0.0
-
+          poetry-version: ${{ env.POETRY_VERSION }}
       # @TODO: This is a workaround for there not being a way to check the lock file
       #   See: https://github.com/python-poetry/poetry/issues/453
-      #   NOTE: This isn't ideal as it using the system Python and dirtying the system
-      #     Python libraries.
       - name: Check for lock changes
         run: |
-          PYTHONPATH="${PYTHONPATH}:${HOME}/.poetry/lib" \
+          PYTHONPATH="${PYTHONPATH}:${HOME}/.poetry/lib:${HOME}/.poetry/lib/poetry/_vendor/py${{ env.PYTHON_VERSION }}" \
           python -c "from poetry.factory import Factory; \
             locker = Factory().create_poetry('.').locker; \
             exit(0) if locker.is_locked() and locker.is_fresh() else exit(1)" \
             && echo 'OK'
-
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pypoetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
       - name: Install the Package
-        run: poetry install
-
+        run: poetry install -vvv
       - name: Lint the Code
         run: poetry run ni-python-styleguide lint
 

--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -40,7 +40,7 @@ jobs:
           path: ~/.cache/pypoetry/virtualenvs
           key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
       - name: Install the Package
-        run: poetry install -vvv
+        run: poetry install
       - name: Lint the Code
         run: poetry run ni-python-styleguide lint
 


### PR DESCRIPTION
Changes:
- Use `poetry` 1.1.6
- Run the checks in a different job, and on 3.9
- No longer `pip install poetry` to run lock check
- Use `setup-python` v2
- Use caching for PR as well