### PR TITLE
Avoid index errors when input file is empty

### DIFF
--- a/ni_python_styleguide/_acknowledge_existing_errors/__init__.py
+++ b/ni_python_styleguide/_acknowledge_existing_errors/__init__.py
@@ -73,6 +73,10 @@ def acknowledge_lint_errors(lint_errors):
     for bad_file, errors_in_file in lint_errors_by_file.items():
         path = pathlib.Path(bad_file)
         lines = path.read_text().splitlines(keepends=True)
+        # sometimes errors are reported on line 1 for empty files.
+        # to make suppressions work for those cases, add an empty line.
+        if len(lines) == 0:
+            lines = [""]
         multiline_checker = _InMultiLineStringChecker(error_file=bad_file)
 
         # to avoid double marking a line with the same code, keep track of lines and codes
@@ -80,9 +84,9 @@ def acknowledge_lint_errors(lint_errors):
         for error in errors_in_file:
             skip = 0
 
-            while multiline_checker.in_multiline_string(
+            while error.line + skip < len(lines) and multiline_checker.in_multiline_string(
                 lineno=error.line + skip
-            ) and error.line + skip < len(lines):
+            ):
                 # find when the multiline ends
                 skip += 1
 

--- a/tests/test_cli/acknowledge_existing_errors_test_cases__snapshots/blank_file_tests/output.py
+++ b/tests/test_cli/acknowledge_existing_errors_test_cases__snapshots/blank_file_tests/output.py
@@ -1,0 +1,1 @@
+  # noqa D100: Missing docstring in public module (auto-generated noqa)


### PR DESCRIPTION
When we try to add suppressions in empty files, it results in index out of range errors. Really, it's a result of a linter error being reported on a non-existent line (i.e. line 1 of empty file). The _add_noqa_to_line function takes in the array of lines and modifies the contents, so the easiest way to avoid this problem is to populate the lines array with a single blank line when the file is empty. Also, the multiline checker has a similar problem, but we can avoid that easily by checking that the error.line is within range _before_ calling multiline_checker.in_multiline_string.