### PR TITLE
Fix bug 83

### DIFF
--- a/ni_python_styleguide/_fix.py
+++ b/ni_python_styleguide/_fix.py
@@ -90,6 +90,13 @@ def _handle_multiple_import_lines(bad_file: pathlib.Path):
             print(working_line, end="")
 
 
+def _format_imports(file: pathlib.Path, app_import_names: Iterable[str]) -> None:
+    _sort_imports(file, app_import_names=app_import_names)
+    _format.format(file, "--line-length=300")  # condense any split lines
+    _handle_multiple_import_lines(file)
+    _format.format(file)
+
+
 def fix(
     exclude: str,
     app_import_names: str,
@@ -130,11 +137,7 @@ def fix(
     failed_files = []
     for bad_file, errors_in_file in lint_errors_by_file.items():
         try:
-            _format.format(bad_file)
-            _sort_imports(bad_file, app_import_names=app_import_names)
-            _format.format(bad_file, "--line-length=300")  # condense any split lines
-            _handle_multiple_import_lines(bad_file)
-            _format.format(bad_file)
+            _format_imports(file=bad_file, app_import_names=app_import_names)
             remaining_lint_errors_in_file = _utils.lint.get_errors_to_process(
                 exclude,
                 app_import_names,

--- a/ni_python_styleguide/_fix.py
+++ b/ni_python_styleguide/_fix.py
@@ -129,13 +129,8 @@ def fix(
 
     failed_files = []
     for bad_file, errors_in_file in lint_errors_by_file.items():
-        errors_in_file: List[_utils.lint.LintError]
         try:
             _format.format(bad_file)
-            line_to_codes_mapping = defaultdict(set)
-            for error in errors_in_file:
-                # humans talk 1-based, enumerate is 0-based
-                line_to_codes_mapping[int(error.line) - 1].add(error.code)
             _sort_imports(bad_file, app_import_names=app_import_names)
             _format.format(bad_file, "--line-length=300")  # condense any split lines
             _handle_multiple_import_lines(bad_file)
@@ -154,7 +149,6 @@ def fix(
                     extend_ignore=extend_ignore,
                     aggressive=aggressive,
                     file_or_dir=[bad_file],
-                    errors_in_file=remaining_lint_errors_in_file,
                 )
         except AttributeError as e:
             failed_files.append((bad_file, e))

--- a/ni_python_styleguide/_fix.py
+++ b/ni_python_styleguide/_fix.py
@@ -146,6 +146,7 @@ def fix(
     failed_files = []
     for bad_file, errors_in_file in lint_errors_by_file.items():
         try:
+            _format.format(bad_file)
             _format_imports(file=bad_file, app_import_names=app_import_names)
             remaining_lint_errors_in_file = _utils.lint.get_errors_to_process(
                 exclude,

--- a/ni_python_styleguide/_utils/__init__.py
+++ b/ni_python_styleguide/_utils/__init__.py
@@ -1,4 +1,6 @@
+from . import code_analysis  # noqa: F401
 from . import lint  # noqa: F401
 from . import string_helpers  # noqa: F401
+from . import temp_file  # noqa: F401
 
 DEFAULT_ENCODING = "UTF-8"

--- a/ni_python_styleguide/_utils/code_analysis.py
+++ b/ni_python_styleguide/_utils/code_analysis.py
@@ -4,12 +4,12 @@ from typing import Tuple
 
 
 def find_import_region(file: pathlib.Path) -> Tuple[int, int]:
-    """Return the index of the first import line and the last import line that precedes any other code.
+    """Return the index of the first last import line that precedes any other code.
 
     Note: will not handle try/except imports
 
     file: pathlib.Path path to file to evaluate
-    Return: Tuple[int, int] the start and ending lines (1 based) during which the module level imports are
+    Return: Tuple[int, int] the start and ending lines (0 based) of the module level imports
     """
     file_contents = file.read_text()
     tree = ast.parse(file_contents)

--- a/ni_python_styleguide/_utils/code_analysis.py
+++ b/ni_python_styleguide/_utils/code_analysis.py
@@ -1,0 +1,23 @@
+import ast
+import pathlib
+from typing import Tuple
+
+def find_import_region(file: pathlib.Path) -> Tuple[int, int]:
+    """Return the index of the first import line and the last import line that precedes any other code.
+
+    Note: will not handle try/except imports
+
+    file: pathlib.Path path to file to evaluate
+    Return: Tuple[int, int] the start and ending lines (1 based) during which the module level imports are
+    """
+    file_contents = file.read_text()
+    tree = ast.parse(file_contents)
+    end = start = 0
+    for node in tree.body: # only walk top level items
+        if isinstance(node, ast.Expr) and isinstance(node.value, ast.Str):
+            continue
+        if isinstance(node, ast.Import) or isinstance(node, ast.ImportFrom):
+            continue
+        end = node.lineno - 1
+        break
+    return start, end

--- a/ni_python_styleguide/_utils/code_analysis.py
+++ b/ni_python_styleguide/_utils/code_analysis.py
@@ -2,6 +2,7 @@ import ast
 import pathlib
 from typing import Tuple
 
+
 def find_import_region(file: pathlib.Path) -> Tuple[int, int]:
     """Return the index of the first import line and the last import line that precedes any other code.
 
@@ -13,7 +14,7 @@ def find_import_region(file: pathlib.Path) -> Tuple[int, int]:
     file_contents = file.read_text()
     tree = ast.parse(file_contents)
     end = start = 0
-    for node in tree.body: # only walk top level items
+    for node in tree.body:  # only walk top level items
         if isinstance(node, ast.Expr) and isinstance(node.value, ast.Str):
             continue
         if isinstance(node, ast.Import) or isinstance(node, ast.ImportFrom):

--- a/ni_python_styleguide/_utils/temp_file.py
+++ b/ni_python_styleguide/_utils/temp_file.py
@@ -5,6 +5,10 @@ from contextlib import contextmanager
 
 @contextmanager
 def multi_access_tempfile(suffix=".txt", delete=True):
+    """Tempfile that has been created and closed and will be deleted after this context.
+
+    Used to allow writing to a temp file multiple times.
+    """
     temp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
     temp.close()
     temp_path = pathlib.Path(temp.name)

--- a/ni_python_styleguide/_utils/temp_file.py
+++ b/ni_python_styleguide/_utils/temp_file.py
@@ -1,0 +1,16 @@
+
+from contextlib import contextmanager
+
+import tempfile
+import pathlib
+
+@contextmanager
+def multi_access_tempfile(suffix=".txt", delete=True):
+        temp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+        temp.close()
+        temp_path = pathlib.Path(temp.name)
+        try:
+            yield temp_path
+        finally:
+            if delete:
+                temp_path.unlink()

--- a/ni_python_styleguide/_utils/temp_file.py
+++ b/ni_python_styleguide/_utils/temp_file.py
@@ -1,16 +1,15 @@
-
+import pathlib
+import tempfile
 from contextlib import contextmanager
 
-import tempfile
-import pathlib
 
 @contextmanager
 def multi_access_tempfile(suffix=".txt", delete=True):
-        temp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
-        temp.close()
-        temp_path = pathlib.Path(temp.name)
-        try:
-            yield temp_path
-        finally:
-            if delete:
-                temp_path.unlink()
+    temp = tempfile.NamedTemporaryFile(suffix=suffix, delete=False)
+    temp.close()
+    temp_path = pathlib.Path(temp.name)
+    try:
+        yield temp_path
+    finally:
+        if delete:
+            temp_path.unlink()

--- a/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/input.py
+++ b/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/input.py
@@ -125,3 +125,12 @@ def fix(exclude, app_import_names, extend_ignore, file_or_dir, *_, aggressive=Fa
             "Failed to format files:\n"
             + "\n".join([f"{file}: {error}" for file, error in failed_files])
         )
+
+
+class ExceptionClassWithBadName(  # noqa N818: exception name 'ExceptionClassWithBadName' should be named with an Error suffix (auto-generated noqa)
+    Exception
+):
+
+    """Error class with a bad name."""
+
+    pass

--- a/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/input.py
+++ b/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/input.py
@@ -130,7 +130,6 @@ def fix(exclude, app_import_names, extend_ignore, file_or_dir, *_, aggressive=Fa
 class ExceptionClassWithBadName(  # noqa N818: exception name 'ExceptionClassWithBadName' should be named with an Error suffix (auto-generated noqa)
     Exception
 ):
-
     """Error class with a bad name."""
 
     pass

--- a/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/output.py
+++ b/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/output.py
@@ -129,3 +129,11 @@ def fix(exclude, app_import_names, extend_ignore, file_or_dir, *_, aggressive=Fa
             "Failed to format files:\n"
             + "\n".join([f"{file}: {error}" for file, error in failed_files])
         )
+
+
+class ExceptionClassWithBadName(  # noqa N818: exception name 'ExceptionClassWithBadName' should be named with an Error suffix (auto-generated noqa)
+    Exception
+):
+    """Error class with a bad name."""
+
+    pass

--- a/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/output__aggressive.py
+++ b/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/output__aggressive.py
@@ -129,3 +129,11 @@ def fix(exclude, app_import_names, extend_ignore, file_or_dir, *_, aggressive=Fa
             "Failed to format files:\n"
             + "\n".join([f"{file}: {error}" for file, error in failed_files])
         )
+
+
+class ExceptionClassWithBadName(  # noqa N818: exception name 'ExceptionClassWithBadName' should be named with an Error suffix (auto-generated noqa)
+    Exception
+):
+    """Error class with a bad name."""
+
+    pass


### PR DESCRIPTION
Fix #83 

Fix issue where non-aggressive was moving comments off the correct line (affecting test)

* Wrote a failing test that showed error
* Fix parameters to second call (for `--aggressive`) to `_acknowledge_existing_errors.acknowledge_lint_errors`
* extract formatting imports to `_fix._format_imports`
* Create:
    *  `_utils.temp_file.multi_access_tempfile` to simplify working on imports section alone
    * `_utils.code_analysis.find_import_region` to simplify identifying the imports section
* Re-work `_fix._format_imports` to use these to take take *only* the import/docstring lines at the start of the file  and condense them.
* Test now passes