### PR TITLE
Use black profile with isort to reduce manual work

### DIFF
--- a/ni_python_styleguide/_config_constants.py
+++ b/ni_python_styleguide/_config_constants.py
@@ -4,3 +4,4 @@ __FILE_DIR = pathlib.Path(__file__).parent
 
 FLAKE8_CONFIG_FILE = __FILE_DIR / "config.ini"
 BLACK_CONFIG_FILE = __FILE_DIR / "config.toml"
+ISORT_CONFIG_FILE = BLACK_CONFIG_FILE

--- a/ni_python_styleguide/_fix.py
+++ b/ni_python_styleguide/_fix.py
@@ -7,8 +7,8 @@ from typing import Iterable
 
 import isort
 
-from ni_python_styleguide import _config_constants
 from ni_python_styleguide import _acknowledge_existing_errors
+from ni_python_styleguide import _config_constants
 from ni_python_styleguide import _format
 from ni_python_styleguide import _utils
 

--- a/ni_python_styleguide/_fix.py
+++ b/ni_python_styleguide/_fix.py
@@ -79,20 +79,6 @@ def _sort_imports(file: pathlib.Path, app_import_names):
     file.write_text(output)
 
 
-def _handle_multiple_import_lines(bad_file: pathlib.Path):
-    multiline_string_checker = _utils.string_helpers.InMultiLineStringChecker(
-        lines=bad_file.read_text(encoding=_utils.DEFAULT_ENCODING).splitlines()
-    )
-    with fileinput.FileInput(files=[str(bad_file)], inplace=True) as f:
-        for line_no, line in enumerate(f):
-            working_line = line
-            if multiline_string_checker.in_multiline_string(line_no + 1):
-                print(working_line, end="")
-                continue
-            working_line = _split_imports_line(working_line)
-            print(working_line, end="")
-
-
 def _format_imports(file: pathlib.Path, app_import_names: Iterable[str]) -> None:
     _sort_imports(file, app_import_names=app_import_names)
     _format.format(file)

--- a/ni_python_styleguide/config.toml
+++ b/ni_python_styleguide/config.toml
@@ -4,3 +4,8 @@
 
 [tool.black]
 line-length = 100
+
+[tool.isort]
+profile = "black"
+combine_as_imports = true
+force_single_line = true

--- a/tests/test_cli/fix_test_cases__snapshots/basic_example/output.py
+++ b/tests/test_cli/fix_test_cases__snapshots/basic_example/output.py
@@ -2,9 +2,9 @@
 import pathlib
 from os import access
 from os import path
-from typing import (
+from typing import (  # noqa F401: un-used import comment that is actually used, should get removed in --aggressive (auto-generated noqa)
     Hashable,
-)  # noqa F401: un-used import comment that is actually used, should get removed in --aggressive (auto-generated noqa)
+)
 from typing import Iterable
 from typing import List
 


### PR DESCRIPTION
I've learned that `isort` now has a `black` profile allowing it to play nicely with `black`.

To start investigating bringing `flake8-isort` in, I opted to first test what configurations we would need to match our current style.

Changing to configuring the call to `isort` within `_sort_imports` removes the need for the custom logic around splitting multi-import lines, so choosing to contribute this simplification at this point.