### PR TITLE
Drop 3.6 support

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
+        python-version: [3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, 3.10, 3.11]
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/poetry.lock
+++ b/poetry.lock
@@ -30,7 +30,6 @@ python-versions = ">=3.6.2"
 
 [package.dependencies]
 click = ">=8.0.0"
-dataclasses = {version = ">=0.6", markers = "python_version < \"3.7\""}
 mypy-extensions = ">=0.4.3"
 pathspec = ">=0.9.0"
 platformdirs = ">=2"
@@ -63,14 +62,6 @@ description = "Cross-platform colored terminal text."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-
-[[package]]
-name = "dataclasses"
-version = "0.8"
-description = "A backport of the dataclasses module for Python 3.6"
-category = "main"
-optional = false
-python-versions = ">=3.6, <3.7"
 
 [[package]]
 name = "flake8"
@@ -382,8 +373,8 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=4.6)", "pytest-black (
 
 [metadata]
 lock-version = "1.1"
-python-versions = ">=3.6.2"
-content-hash = "2d34e646615710b9fae58dd658469d54f4df3280549af506eaf4d3db63d81036"
+python-versions = "^3.7"
+content-hash = "e0f06ca6f2ff7fb1b2e2ff8a5e5996738070a0066f3e5c4a37efae7a8d206bfb"
 
 [metadata.files]
 atomicwrites = [
@@ -425,10 +416,6 @@ click = [
 colorama = [
     {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
     {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
-]
-dataclasses = [
-    {file = "dataclasses-0.8-py3-none-any.whl", hash = "sha256:0201d89fa866f68c8ebd9d08ee6ff50c0b255f8ec63a71c16fda7af82bb887bf"},
-    {file = "dataclasses-0.8.tar.gz", hash = "sha256:8479067f342acf957dc82ec415d355ab5edb7e7646b90dc6e2fd1d96ad084c97"},
 ]
 flake8 = [
     {file = "flake8-3.9.2-py2.py3-none-any.whl", hash = "sha256:bf8fd333346d844f616e8d47905ef3a3384edae6b4e9beb0c5101e25e3110907"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ python = "^3.7"
 
 # Tools we aggregate
 flake8 = "^3.8"  # flake8 4.x broke the test
-black = ">=21.10b0"
+black = ">=22.3"
 
 # Additional support libraries
 # These dependencies were selected because they are already used by black.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ni-python-styleguide"
 # The -alpha.0 here denotes a source based version
 # This is removed when released through the Publish-Package.yml GitHub action
 # Official PyPI releases follow Major.Minor.Patch
-version = "0.1.14-alpha.0"
+version = "0.2.0-alpha.0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ black = ">=22.3"
 # These dependencies were selected because they are already used by black.
 click = ">=7.1.2"
 toml = ">=0.10.1"
-isort = {version=">=5.10", python=">=3.6,<4"}
+isort = ">=5.10"
 
 
 # flake8 plugins should be listed here (in alphabetical order)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ license = "MIT"
 include = ["ni_python_styleguide/config.toml"]
 
 [tool.poetry.dependencies]
-python = ">=3.6.2"
+python = "^3.7"
 
 # Tools we aggregate
 flake8 = "^3.8"  # flake8 4.x broke the test


### PR DESCRIPTION
# Reasons
3.6 Has been EOL for a while now.

GitHub actions linux-latest (I suspect, U2022) no longer has 3.6 on it.

# Implementation

* [declare we support Python 3 starting with .7](/ni/python-styleguide/pull/96/commits/7c4c37762ea49abacab54affb043241347aa4641)
* [update black minimum to the first stable release](/ni/python-styleguide/pull/96/commits/a58946f9be61961dbc126a7de06499db0441b2d3)
* [remove no longer needed python version filter for isort](/ni/python-styleguide/pull/96/commits/038f79082c324dfc6b2d7fed6fdac8a7ad022c45)
* [stop testing 3.6](/ni/python-styleguide/pull/96/commits/508a539efe7d1fb644441fa7a0a4963ac7233be5)
* [update lock file](/ni/python-styleguide/pull/96/commits/75867c38a5fac815028e85b21edb42aabf75ca39)
* [bump minor to desgnate support change](/ni/python-styleguide/pull/96/commits/53b3bcc933b7982abc983f373fa5400f22eca053)
* [let's also test the newer versions](/ni/python-styleguide/pull/96/commits/d040f9e8010bd48f560432df80aac23c7d2f427d)
* [that's 10, not 1](/ni/python-styleguide/pull/96/commits/2641b3d9406c505917bddb5d2c568cec67596fa3)