### PR TITLE
Fix no split submodule imports

### DIFF
--- a/ni_python_styleguide/config.toml
+++ b/ni_python_styleguide/config.toml
@@ -8,4 +8,3 @@ line-length = 100
 [tool.isort]
 profile = "black"
 combine_as_imports = true
-force_single_line = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ni-python-styleguide"
 # The -alpha.0 here denotes a source based version
 # This is removed when released through the Publish-Package.yml GitHub action
 # Official PyPI releases follow Major.Minor.Patch
-version = "0.3.0-alpha.0"
+version = "0.4.0-alpha.0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well

--- a/tests/test_cli/fix_test_cases__snapshots/basic_example/output.py
+++ b/tests/test_cli/fix_test_cases__snapshots/basic_example/output.py
@@ -1,12 +1,10 @@
 """Provide example cases of imports that need sorting and a file that needs formatted."""
 import pathlib
-from os import access
-from os import path
+from os import access, path
 from typing import (  # noqa F401: un-used import comment that is actually used, should get removed in --aggressive (auto-generated noqa)
     Hashable,
 )
-from typing import Iterable
-from typing import List
+from typing import Iterable, List
 
 import pytest
 

--- a/tests/test_cli/fix_test_cases__snapshots/basic_example/output__aggressive.py
+++ b/tests/test_cli/fix_test_cases__snapshots/basic_example/output__aggressive.py
@@ -1,10 +1,7 @@
 """Provide example cases of imports that need sorting and a file that needs formatted."""
 import pathlib
-from os import access
-from os import path
-from typing import Hashable
-from typing import Iterable
-from typing import List
+from os import access, path
+from typing import Hashable, Iterable, List
 
 import pytest
 

--- a/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/output.py
+++ b/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/output.py
@@ -3,13 +3,11 @@ import fileinput
 import logging
 import pathlib
 from collections import defaultdict
-from typing import Iterable
-from typing import List
+from typing import Iterable, List
 
 import isort
 
-from ni_python_styleguide import _format
-from ni_python_styleguide import _utils
+from ni_python_styleguide import _format, _utils
 from ni_python_styleguide._acknowledge_existing_errors import _lint_errors_parser
 
 _module_logger = logging.getLogger(__name__)

--- a/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/output__aggressive.py
+++ b/tests/test_cli/fix_test_cases__snapshots/more_complicated_example/output__aggressive.py
@@ -3,13 +3,11 @@ import fileinput
 import logging
 import pathlib
 from collections import defaultdict
-from typing import Iterable
-from typing import List
+from typing import Iterable, List
 
 import isort
 
-from ni_python_styleguide import _format
-from ni_python_styleguide import _utils
+from ni_python_styleguide import _format, _utils
 from ni_python_styleguide._acknowledge_existing_errors import _lint_errors_parser
 
 _module_logger = logging.getLogger(__name__)


### PR DESCRIPTION
Fixes #97 

Based on a poll with NI engineers, we are choosing to align on ["Do not put module level imports on the same line"](https://ni.github.io/python-styleguide/#O-1-1), but allowing sub-module imports on the same line.
