### PR TITLE
Ignore missing docstrings in methods in "tests" dir "test_*.py"

### DIFF
--- a/ni_python_styleguide/config.ini
+++ b/ni_python_styleguide/config.ini
@@ -102,7 +102,7 @@ ignore =
     I101  #  The names in your from import are in the wrong order. (Enforced by E401)
 
 # We want to ignore missing docstrings in test methods as they are self documenting
-per-file-ignores= tests/*:D100,D103
+per-file-ignores= tests/**/test_*.py:D100,D103
 
 # Flake8 includes mccabe by default.
 # We have yet to evaluate it, so ignore the errors for now

--- a/ni_python_styleguide/config.ini
+++ b/ni_python_styleguide/config.ini
@@ -101,6 +101,9 @@ ignore =
     # flake8-import-order
     I101  #  The names in your from import are in the wrong order. (Enforced by E401)
 
+# We want to ignore missing docstrings in test methods as they are self documenting
+per-file-ignores= tests/*:D100,D103
+
 # Flake8 includes mccabe by default.
 # We have yet to evaluate it, so ignore the errors for now
 extend-ignore=C90

--- a/tests/test_cli/test_lint.py
+++ b/tests/test_cli/test_lint.py
@@ -2,6 +2,7 @@
 
 import itertools
 import textwrap
+
 import pytest
 import toml
 
@@ -165,9 +166,17 @@ def test_lint__ignores_venv_by_default(styleguide_lint, tmp_path):
 
 
 def test_lint__ignores_missing_docstrings_in_tests_dir(styleguide_lint, tmp_path):
-    """Tests that we ingore 'public methods must have docstrings' in tests dir."""
+    (tmp_path / "tests" / "test_spam").mkdir(parents=True)
+    (tmp_path / "tests" / "test_spam" / "test_spam.py").write_text(NO_DOC_STRING)
+
+    result = styleguide_lint()
+
+    assert result, result.output
+
+
+def test_lint__checks_docstrings_tests_dir_conftest(styleguide_lint, tmp_path):
     (tmp_path / "tests").mkdir()
-    (tmp_path / "tests" / "test_spam.py").write_text(NO_DOC_STRING)
+    (tmp_path / "tests" / "conftest.py").write_text(NO_DOC_STRING)
 
     result = styleguide_lint()
 

--- a/tests/test_cli/test_lint.py
+++ b/tests/test_cli/test_lint.py
@@ -1,12 +1,18 @@
 """Tests for the "lint" subcommand of ni-python-styleguide."""
 
 import itertools
-
+import textwrap
 import pytest
 import toml
 
 
 TOO_LONG_LINE = "a_really_long_order = [" + ", ".join(itertools.repeat('"spam"', 10)) + "]\n"
+NO_DOC_STRING = textwrap.dedent(
+    f"""\
+    def my_method():
+        assert True
+    """
+)
 
 
 @pytest.fixture
@@ -148,10 +154,20 @@ def test_lint__no_args_lints_subdirs(styleguide_lint, tmp_path):
     assert "subdir/spam.py" in result.output.replace("\\", "/")
 
 
-def test_lint__lignores_venv_by_default(styleguide_lint, tmp_path):
+def test_lint__ignores_venv_by_default(styleguide_lint, tmp_path):
     """Tests that we exclude ".venv" dir by default."""
     (tmp_path / ".venv").mkdir()
     (tmp_path / ".venv" / "spam.py").write_text(TOO_LONG_LINE)
+
+    result = styleguide_lint()
+
+    assert result, result.output
+
+
+def test_lint__ignores_missing_docstrings_in_tests_dir(styleguide_lint, tmp_path):
+    """Tests that we ingore 'public methods must have docstrings' in tests dir."""
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_spam.py").write_text(NO_DOC_STRING)
 
     result = styleguide_lint()
 

--- a/tests/test_cli/test_lint.py
+++ b/tests/test_cli/test_lint.py
@@ -174,13 +174,15 @@ def test_lint__ignores_missing_docstrings_in_tests_dir(styleguide_lint, tmp_path
     assert result, result.output
 
 
-def test_lint__checks_docstrings_tests_dir_conftest(styleguide_lint, tmp_path):
+def test_lint__checks_docstrings_in_test_helper_methods(styleguide_lint, tmp_path):
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "conftest.py").write_text(NO_DOC_STRING)
 
     result = styleguide_lint()
 
-    assert result, result.output
+    # D100: Missing docstring in public module
+    # D103: Missing docstring in public function
+    assert "D100" and "D103" in result.output, result.output
 
 
 def test_lint__exclude__excludes_file(styleguide_lint_with_options, tmp_path):


### PR DESCRIPTION
Added 'per-file-ignores' for D100, D103 on files in "tests" dir named 'test_*.py'. Still require docstrings on public helper method.

D100: Missing docstring in public module
D103: Missing docstring in public function

These are not needed as test methods and modules are self documenting.