### PR TITLE
Use native gh tooling to raise pr

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -10,9 +10,6 @@ on:
       - pyproject.toml
       - docs/Coding-Conventions.md
       - .github/workflows/PR.yml
-    types:
-      - opened
-      - synchronize
 
 env:
   POETRY_VERSION: 1.2.2

--- a/.github/workflows/Update-Poetry-Lock.yml
+++ b/.github/workflows/Update-Poetry-Lock.yml
@@ -28,27 +28,43 @@ jobs:
           ref: main # This is the branch the PR is to be created from
           persist-credentials: true # make the token that is used the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-
+      - name: Store vars
+        id: vars
+        run: |
+          echo "sha_short=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "branch_name=automated-updates/update-poetry-lock" >> $GITHUB_OUTPUT
+      - name: Create branch
+        run: git checkout -b ${{ steps.vars.outputs.branch_name }}
       - uses: actions/setup-python@v2
         with:
           python-version: ${{ env.PYTHON_VERSION }}
       - uses: Gr1N/setup-poetry@v8
         with:
           poetry-version: ${{ env.POETRY_VERSION }}
+      - name: Configure git user
+        # https://github.com/actions/checkout/discussions/479
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
       - name: Check for lock changes
         run: |
           poetry lock
+          git commit -am "Update poetry lock file" || exit 0
           poetry install
           poetry run ni-python-styleguide fix
+          git commit -am "Update formatting" || true
+          git push --force --set-upstream origin ${{ steps.vars.outputs.branch_name }}
+      # based on https://stackoverflow.com/a/73340290/8100990
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v4
-        with:
-          commit-message: Update poetry lock and reformat
-          title: Update Poetry Lock
-          branch: aotumated-updates/update-poetry-lock
-          branch-suffix: short-commit-hash
-          body: |
-              # Update Poetry Lock
-              Ran poetry lock, install, then ni-python-styleguide fix to reformat any changes.
-          base: main
-          delete-branch: true
+        run: | 
+          gh pr create -B main -H ${{ steps.vars.outputs.branch_name }} --title 'Update poetry lock and reformat' --body '# Update Poetry Lock
+
+          Ran:
+          * `poetry lock`,
+          * `poetry install`, then
+          * `ni-python-styleguide fix` to reformat any changes.
+
+          \-\-\-
+            Created by Github action'
+        env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Justification

PR's keep not running checks [e.g., #137]

# Implementation
* Change from using `peter-evans/create-pull-request@v4` to `gh` cli directly
* Remove trigger events from PRs to use the defaults.

# Testing
Using fork with protected main, iterated until PR is formatted well and appears to be consistently running checks (https://github.com/mshafer1/ni-python-styleguide/pull/5)