### PR TITLE
switch the pat used to create the PR to enable PR checks

### DIFF
--- a/.github/workflows/Update-Poetry-Lock.yml
+++ b/.github/workflows/Update-Poetry-Lock.yml
@@ -67,4 +67,4 @@ jobs:
           \-\-\-
             Created by Github action'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.ADMIN_PAT }}


### PR DESCRIPTION
peter-evans has learned that PR checks will not run on automated PRs if the PR is created using the github token. 
According to his sources, this is to prevent forks from abusing the tokens.
https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs

A workaround, is to use a repo level PAT to create the PR.

Tested in fork: https://github.com/mshafer1/ni-python-styleguide/pull/11