### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -46,7 +46,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, windows-latest, ubuntu-latest]
-        python-version: [3.7, 3.8, 3.9, '3.10', '3.11']
+        python-version: [3.7, 3.8, 3.9, '3.10', 3.11, 3.12]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/docs/Coding-Conventions.md
+++ b/docs/Coding-Conventions.md
@@ -388,7 +388,7 @@ if cheese is None:
 
 ```python
 # Bad
-if type(num_cheeses) is type(1):
+if type(num_cheeses) == type(1):
     buy(num_cheeses)
 ```
 

--- a/ni_python_styleguide/config.ini
+++ b/ni_python_styleguide/config.ini
@@ -73,18 +73,28 @@ ignore =
     # The same goes for the "descriptive"-mood error, if one was to be added to pydocstyle.
     D401
     # Conflicts with recommending Google style DocStrings
-    D406  # Section name should end with a newline -> forces a newline at end of DocString
+    # D406 - Section name should end with a newline -> forces a newline at end of DocString
+    D406
     # Ignoring things enforced by black
-    D200  # One-line docstring should fit on one line with quotes
-    D206  # Docstring should be indented with spaces, not tabs
-    D207  # Docstring is under-indented
-    D208  # Docstring is over-indented
-    D210  # No whitespaces allowed surrounding docstring text
-    D300  # Use """triple double quotes"""
+    # D200 - One-line docstring should fit on one line with quotes
+    D200
+    # D206 - Docstring should be indented with spaces, not tabs
+    D206
+    # D207 - Docstring is under-indented
+    D207
+    # D208 - Docstring is over-indented
+    D208
+    # D210 - No whitespaces allowed surrounding docstring text
+    D210
+    # D300 - Use """triple double quotes"""
+    D300
     # Conflicts with other codes
-    D203  # 1 blank line required before class docstring
-    D213  # Multi-line docstring summary should start at the second line
-    D400  # First line should end with a period
+    # D203 - 1 blank line required before class docstring
+    D203
+    # D213 - Multi-line docstring summary should start at the second line
+    D213
+    # D400 - First line should end with a period
+    D400
     # Recommending Google, so these don't apply - http://www.pydocstyle.org/en/stable/error_codes.html#:~:text=The%20google%20convention%20added%20in%20v4.0.0
     D203
     D204
@@ -99,7 +109,8 @@ ignore =
     D409
     D413
     # flake8-import-order
-    I101  #  The names in your from import are in the wrong order. (Enforced by E401)
+    # I101 - The names in your from import are in the wrong order. (Enforced by E401)
+    I101
 
 # We want to ignore missing docstrings in test methods as they are self documenting
 per-file-ignores= tests/**/test_*.py:D100,D103

--- a/poetry.lock
+++ b/poetry.lock
@@ -68,6 +68,19 @@ pycodestyle = ">=2.9.0,<2.10.0"
 pyflakes = ">=2.5.0,<2.6.0"
 
 [[package]]
+name = "flake8"
+version = "6.1.0"
+description = "the modular source code checker: pep8 pyflakes and co"
+category = "main"
+optional = false
+python-versions = ">=3.8.1"
+
+[package.dependencies]
+mccabe = ">=0.7.0,<0.8.0"
+pycodestyle = ">=2.11.0,<2.12.0"
+pyflakes = ">=3.1.0,<3.2.0"
+
+[[package]]
 name = "flake8-black"
 version = "0.3.6"
 description = "flake8 plugin to call black as a code style validator"
@@ -105,6 +118,7 @@ python-versions = "*"
 
 [package.dependencies]
 pycodestyle = "*"
+setuptools = "*"
 
 [[package]]
 name = "importlib-metadata"
@@ -226,6 +240,14 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "pycodestyle"
+version = "2.11.0"
+description = "Python style guide checker"
+category = "main"
+optional = false
+python-versions = ">=3.8"
+
+[[package]]
 name = "pydocstyle"
 version = "6.3.0"
 description = "Python docstring style checker"
@@ -247,6 +269,14 @@ description = "passive checker of Python programs"
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "pyflakes"
+version = "3.1.0"
+description = "passive checker of Python programs"
+category = "main"
+optional = false
+python-versions = ">=3.8"
 
 [[package]]
 name = "pytest"
@@ -290,6 +320,19 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 pytest = ">=3.0.0"
+
+[[package]]
+name = "setuptools"
+version = "68.0.0"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-lint", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-ruff", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
 
 [[package]]
 name = "snowballstemmer"
@@ -341,12 +384,12 @@ python-versions = ">=3.7"
 
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
-testing = ["big-o", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
+testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more-itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "a82e2dfbe3b0fe550aa5db0ad2eca318db77d9bd468cb78f902abd98e3921621"
+content-hash = "8c3f0d8fe73c715b00b20afd4b8334b143754e3899fd2fa54125708d79190a5a"
 
 [metadata.files]
 black = [
@@ -391,6 +434,8 @@ exceptiongroup = [
 flake8 = [
     {file = "flake8-5.0.4-py2.py3-none-any.whl", hash = "sha256:7a1cf6b73744f5806ab95e526f6f0d8c01c66d7bbe349562d22dfca20610b248"},
     {file = "flake8-5.0.4.tar.gz", hash = "sha256:6fbe320aad8d6b95cec8b8e47bc933004678dc63095be98528b7bdd2a9f510db"},
+    {file = "flake8-6.1.0-py2.py3-none-any.whl", hash = "sha256:ffdfce58ea94c6580c77888a86506937f9a1a227dfcd15f245d694ae20a6b6e5"},
+    {file = "flake8-6.1.0.tar.gz", hash = "sha256:d5b3857f07c030bdb5bf41c7f53799571d75c4491748a3adcd47de929e34cd23"},
 ]
 flake8-black = [
     {file = "flake8-black-0.3.6.tar.gz", hash = "sha256:0dfbca3274777792a5bcb2af887a4cad72c72d0e86c94e08e3a3de151bb41c34"},
@@ -447,6 +492,8 @@ pluggy = [
 pycodestyle = [
     {file = "pycodestyle-2.9.1-py2.py3-none-any.whl", hash = "sha256:d1735fc58b418fd7c5f658d28d943854f8a849b01a5d0a1e6f3f3fdd0166804b"},
     {file = "pycodestyle-2.9.1.tar.gz", hash = "sha256:2c9607871d58c76354b697b42f5d57e1ada7d261c261efac224b664affdc5785"},
+    {file = "pycodestyle-2.11.0-py2.py3-none-any.whl", hash = "sha256:5d1013ba8dc7895b548be5afb05740ca82454fd899971563d2ef625d090326f8"},
+    {file = "pycodestyle-2.11.0.tar.gz", hash = "sha256:259bcc17857d8a8b3b4a2327324b79e5f020a13c16074670f9c8c8f872ea76d0"},
 ]
 pydocstyle = [
     {file = "pydocstyle-6.3.0-py3-none-any.whl", hash = "sha256:118762d452a49d6b05e194ef344a55822987a462831ade91ec5c06fd2169d019"},
@@ -455,6 +502,8 @@ pydocstyle = [
 pyflakes = [
     {file = "pyflakes-2.5.0-py2.py3-none-any.whl", hash = "sha256:4579f67d887f804e67edb544428f264b7b24f435b263c4614f384135cea553d2"},
     {file = "pyflakes-2.5.0.tar.gz", hash = "sha256:491feb020dca48ccc562a8c0cbe8df07ee13078df59813b83959cbdada312ea3"},
+    {file = "pyflakes-3.1.0-py2.py3-none-any.whl", hash = "sha256:4132f6d49cb4dae6819e5379898f2b8cce3c5f23994194c24b77d5da2e36f774"},
+    {file = "pyflakes-3.1.0.tar.gz", hash = "sha256:a0aae034c444db0071aa077972ba4768d40c830d9539fd45bf4cd3f8f6992efc"},
 ]
 pytest = [
     {file = "pytest-7.3.1-py3-none-any.whl", hash = "sha256:3799fa815351fea3a5e96ac7e503a96fa51cc9942c3753cda7651b93c1cfa362"},
@@ -467,6 +516,10 @@ pytest-click = [
 pytest-snapshot = [
     {file = "pytest-snapshot-0.9.0.tar.gz", hash = "sha256:c7013c3abc3e860f9feff899f8b4debe3708650d8d8242a61bf2625ff64db7f3"},
     {file = "pytest_snapshot-0.9.0-py3-none-any.whl", hash = "sha256:4b9fe1c21c868fe53a545e4e3184d36bc1c88946e3f5c1d9dd676962a9b3d4ab"},
+]
+setuptools = [
+    {file = "setuptools-68.0.0-py3-none-any.whl", hash = "sha256:11e52c67415a381d10d6b462ced9cfb97066179f0e871399e006c4ab101fc85f"},
+    {file = "setuptools-68.0.0.tar.gz", hash = "sha256:baf1fdb41c6da4cd2eae722e135500da913332ab3f2f5c7d33af9b492acb5235"},
 ]
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,14 @@ include = ["ni_python_styleguide/config.toml"]
 python = "^3.7"
 
 # Tools we aggregate
-flake8 = "^5.0"
+flake8 = [
+    {version = "^5.0", python = ">=3.7,<3.12"},
+    {version = "^6.1", python = "^3.12"},
+]
+pycodestyle = [
+    {version = "^2.9", python = ">=3.7,<3.12"},
+    {version = "^2.11", python = "^3.12"},
+]
 black = ">=23.1"
 
 # Additional support libraries

--- a/tests/test_cli/acknowledge_existing_errors_test_cases__snapshots/structural_tests/input.py
+++ b/tests/test_cli/acknowledge_existing_errors_test_cases__snapshots/structural_tests/input.py
@@ -55,10 +55,9 @@ class Cheese_Shop:
         except:
             pass
 
-        l = 5
         i = 3
+        j = 5
 
-        if l == True:
-            return False
+        l = (i == True)
 
         return cheese_found

--- a/tests/test_cli/acknowledge_existing_errors_test_cases__snapshots/structural_tests/output.py.txt
+++ b/tests/test_cli/acknowledge_existing_errors_test_cases__snapshots/structural_tests/output.py.txt
@@ -55,10 +55,9 @@ class Cheese_Shop:  # noqa: D101, N801 - Missing docstring in public class (auto
         except:  # noqa: E722 - do not use bare 'except' (auto-generated noqa)
             pass
 
-        l = 5  # noqa: E741 - ambiguous variable name 'l' (auto-generated noqa)
-        i = 3  # noqa: F841 - local variable 'i' is assigned to but never used (auto-generated noqa)
+        i = 3
+        j = 5  # noqa: F841 - local variable 'j' is assigned to but never used (auto-generated noqa)
 
-        if l == True:  # noqa: E741, E712 - ambiguous variable name 'l' (auto-generated noqa), comparison to True should be 'if cond is True:' or 'if cond:' (auto-generated noqa)
-            return False
+        l = (i == True)  # noqa: E712, E741, F841 - comparison to True should be 'if cond is True:' or 'if cond:' (auto-generated noqa), ambiguous variable name 'l' (auto-generated noqa), local variable 'l' is assigned to but never used (auto-generated noqa)
 
         return cheese_found

--- a/tests/test_cli/acknowledge_existing_errors_test_cases__snapshots/structural_tests/output__aggressive.py
+++ b/tests/test_cli/acknowledge_existing_errors_test_cases__snapshots/structural_tests/output__aggressive.py
@@ -69,13 +69,12 @@ class Cheese_Shop:  # noqa: D101, N801 - Missing docstring in public class (auto
         except:  # noqa: E722 - do not use bare 'except' (auto-generated noqa)
             pass
 
-        l = 5  # noqa: E741 - ambiguous variable name 'l' (auto-generated noqa)
-        i = 3  # noqa: F841 - local variable 'i' is assigned to but never used (auto-generated noqa)
+        i = 3
+        j = 5  # noqa: F841 - local variable 'j' is assigned to but never used (auto-generated noqa)
 
-        if (
-            l
+        l = (  # noqa: E741, F841 - ambiguous variable name 'l' (auto-generated noqa), local variable 'l' is assigned to but never used (auto-generated noqa)
+            i
             == True  # noqa: E712 - comparison to True should be 'if cond is True:' or 'if cond:' (auto-generated noqa)
-        ):
-            return False
+        )
 
         return cheese_found


### PR DESCRIPTION
### What does this Pull Request accomplish?

Update version constraints to use `flake8 = "^6.1"` and `pycodestyle = "^2.11"` for Python 3.12 and later. The enhanced f-string support in Python 3.12 changed how the `ast` module parses f-strings, which required updates to `pycodestyle`.

Fix test failures introduced by the update:
- `flake8` no longer tolerates inline comments in the `ignore` field. Comments and error numbers must be on separate lines.
- `pycodestyle` no longer reports "E721 do not compare types, use 'isinstance()'" for comparisons that use the `is` operator.
- `pycodestyle` no longer reports "E741 ambiguous variable name" when using the variable; it only reports this error when assigning the variable.

Update PR workflow to test with Python 3.12.

### Why should this Pull Request be merged?

Fixes #142 

### What testing has been done?

Ran `poetry run pytest -v` with both Python 3.9.13 and 3.12.0.