### PR TITLE
Bump package patch version since last release did not

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [tool.poetry]
 name = "ni-python-styleguide"
-# The -alpha.0 here denotes a source based version
+# The a.0 here denotes a source based version
 # This is removed when released through the Publish-Package.yml GitHub action
 # Official PyPI releases follow Major.Minor.Patch
-version = "0.4.1-alpha.0"
+version = "0.4.2a0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well


### PR DESCRIPTION
# Reason
Our release pipeline was failing on the PAT used to contribute the update version being invalid (https://github.com/ni/python-styleguide/actions/runs/4823902909). That has now been fixed, and we have more functionality/fixes to publish.

# Implementation
`poetry version patch` then `poetry version prepatch`
