### PR TITLE
Also ignore D102 Missing docstring in public method in tests

### DIFF
--- a/ni_python_styleguide/config.ini
+++ b/ni_python_styleguide/config.ini
@@ -113,7 +113,7 @@ ignore =
     I101
 
 # We want to ignore missing docstrings in test methods as they are self documenting
-per-file-ignores= tests/**/test_*.py,tests/test_*.py:D100,D103
+per-file-ignores= tests/**/test_*.py,tests/test_*.py:D100,D103,D102
 
 # Flake8 includes mccabe by default.
 # We have yet to evaluate it, so ignore the errors for now

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ni-python-styleguide"
 # The a.0 here denotes a source based version
 # This is removed when released through the Publish-Package.yml GitHub action
 # Official PyPI releases follow Major.Minor.Patch
-version = "0.4.3a0"
+version = "0.4.4a0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well


### PR DESCRIPTION
Some tests are just public method in a test class. We should also ignore this error in tests folder.