### PR TITLE
add nps add short command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ pytest-snapshot = ">=0.6.3"
 
 [tool.poetry.scripts]
 ni-python-styleguide = 'ni_python_styleguide._cli:main'
+nps = 'ni_python_styleguide._cli:main'
 
 
 [tool.black]


### PR DESCRIPTION
ni-python-styleguide is long to type out, and several people have expressed interest in it having a shorter name to call it by.

By adding "nps", we can provide this much shorter alias.

Note: I searched on command-not-found.com to verify that this is not an already common program name on Linux.