### PR TITLE
Ignore F401 for __init__.py files

### DIFF
--- a/docs/Coding-Conventions.md
+++ b/docs/Coding-Conventions.md
@@ -869,7 +869,7 @@ import os  # Assuming os is never used
 
 ```python
 # Good - assuming we are in a __init__.py file
-from .mysubmodule import spam, eggs # OK even if neither are used in this module
+from .mysubmodule import spam, eggs  # OK even if neither are used in this module
 ```
 
 

--- a/docs/Coding-Conventions.md
+++ b/docs/Coding-Conventions.md
@@ -860,10 +860,18 @@ import cheese_shop.brie
 
 > 💻 This rule is enforced by error code F401
 
+`__init__.py` files are an allowed exception because these are used to declare public APIs.
+
 ```python
 # Bad
 import os  # Assuming os is never used
 ```
+
+```python
+# Good - assuming we are in a __init__.py file
+from .mysubmodule import spam, eggs # OK even if neither are used in this module
+```
+
 
 ### [O.1.9] ❌ **DO NOT** Change an imported object's case 💻
 

--- a/ni_python_styleguide/config.ini
+++ b/ni_python_styleguide/config.ini
@@ -112,8 +112,11 @@ ignore =
     # I101 - The names in your from import are in the wrong order. (Enforced by E401)
     I101
 
-# We want to ignore missing docstrings in test methods as they are self documenting
-per-file-ignores= tests/**/test_*.py,tests/test_*.py:D100,D103,D102
+per-file-ignores=
+    # We want to ignore missing docstrings in test methods as they are self documenting
+    tests/**/test_*.py,tests/test_*.py:D100,D103,D102
+    # __init__.py files routinely import other modules without directly using them
+    __init__.py:F401
 
 # Flake8 includes mccabe by default.
 # We have yet to evaluate it, so ignore the errors for now


### PR DESCRIPTION
These files routinely import other modules without immediately using them with the intention of making them available to the importing module. Moreover, they are rarely even supposed to be used within the same `__init__.py` file. Marking all of them 'noqa: F410' is redundant.