### PR TITLE
Ignore documentation errors in Sphinx config

### DIFF
--- a/ni_python_styleguide/config.ini
+++ b/ni_python_styleguide/config.ini
@@ -115,6 +115,8 @@ ignore =
 per-file-ignores=
     # We want to ignore missing docstrings in test methods as they are self documenting
     tests/**/test_*.py,tests/test_*.py:D100,D103,D102
+    # We don't need to document every Sphinx config
+    docs/conf.py:D1
     # __init__.py files routinely import other modules without directly using them
     __init__.py:F401
 


### PR DESCRIPTION
We don't want to fiddle with docstrings or related noqas in our Sphinx configs. To avoid this, disable docs rules in `docs/conf.py`.

Tested by installing into a package's Poetry env and running `ni-python-styleguide lint`. It now doesn't complain about missing docstrings in `docs/conf.py`.