### PR TITLE
pin to 0.18 because 0.19 is broken

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -495,4 +495,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "0674dc02f387b83c7995f1e0e060a7406c4cb7660b8c1b80939869da9ad90fff"
+content-hash = "3697007f52fcec8fe9a3f6090d1f5866165644fec5fece9344878e9ea59cb315"

--- a/poetry.lock
+++ b/poetry.lock
@@ -495,4 +495,4 @@ files = [
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "3697007f52fcec8fe9a3f6090d1f5866165644fec5fece9344878e9ea59cb315"
+content-hash = "a8aef2d773dabdd18223fcb2aabce153b8a4f45750fe636d15acf5b47143ea16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ isort = ">=5.10"
 # flake8 plugins should be listed here (in alphabetical order)
 flake8-black = ">=0.2.1"
 flake8-docstrings = ">=1.5.0"
-flake8-import-order = ">=0.18.1,!=0.18.3"
+flake8-import-order = ">=0.18.1,<0.19.0" # we're not compatible with 0.19.0 yet due to #226
 flake8-tidy-imports = [
     {version = ">=4.4.1", python = ">=3.7,<3.9"},
     {version=">=4.11.0", python="^3.9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ isort = ">=5.10"
 # flake8 plugins should be listed here (in alphabetical order)
 flake8-black = ">=0.2.1"
 flake8-docstrings = ">=1.5.0"
-flake8-import-order = ">=0.18.1"
+flake8-import-order = ">=0.18.1,!=0.18.3"
 flake8-tidy-imports = [
     {version = ">=4.4.1", python = ">=3.7,<3.9"},
     {version=">=4.11.0", python="^3.9"},


### PR DESCRIPTION
flake8-import-order errors with
```
  File "/home/rfmibuild/myagent/_work/_temp/nidev-setup-oBKZYQJg-py3.8/lib/python3.8/site-packages/flake8_import_order/__init__.py", line 103, in visit_Import
    if node.col_offset == 0 or self._type_checking_import(node):
  File "/home/rfmibuild/myagent/_work/_temp/nidev-setup-oBKZYQJg-py3.8/lib/python3.8/site-packages/flake8_import_order/__init__.py", line 149, in _type_checking_import
    node.parent.test.value.id in {"t", "typing"}
AttributeError: 'Name' object has no attribute 'value'
"""

The above exception was the direct cause of the following exception:
```

Issue [#212](https://github.com/PyCQA/flake8-import-order/issues/212)