### PR TITLE
update publishing flow to use ni/python-actions

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -10,6 +10,8 @@ on:
       - pyproject.toml
       - docs/Coding-Conventions.md
       - .github/workflows/PR.yml
+  workflow_call:
+  workflow_dispatch:
 
 env:
   POETRY_VERSION: 1.8.1

--- a/.github/workflows/Publish-Package.yml
+++ b/.github/workflows/Publish-Package.yml
@@ -2,31 +2,55 @@ name: Publish Package
 
 on:
   release:
-    types: [released]
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: The environment to publish to.
+        default: 'none'
+        required: true
+        type: choice
+        options:
+          - none
+          - pypi
+          - testpypi
 
 env:
-  # Versions are also listed in PR.yml
-  POETRY_VERSION: 1.8.1
-  PYTHON_VERSION: 3.11  # Use latest
+  dist-artifact-name: package-distribution-packages
+  environment: ${{ github.event_name == 'release' && 'pypi' || inputs.environment }}
+  environment-info: |
+    {
+      "pypi": {
+        "base-url": "https://pypi.org",
+        "upload-url": "https://upload.pypi.org/legacy/"
+      },
+      "testpypi": {
+        "base-url": "https://test.pypi.org",
+        "upload-url": "https://test.pypi.org/legacy/"
+      }
+    }
 
 jobs:
-  publish_package:
-    name: Publish Package
+  check_package:
+    name: Check package
+    uses: ./.github/workflows/PR.yml
+  build_package:
+    name: Build package
     runs-on: ubuntu-latest
+    needs: [check_package]
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.release.target_commitish }} # This is the branch the release was created from. Normally main, but can be a dev branch
-          persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
-          fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
-
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python
-        uses: ni/python-actions/setup-python@97860b52be87c788fb6df812bd8d1ca68c7aa885 # v0.3.0
+        uses: ni/python-actions/setup-python@5286c12d65d90b2ea738bd57d452dc4366497581 # v0.4.1
       - name: Set up Poetry
-        uses: ni/python-actions/setup-poetry@97860b52be87c788fb6df812bd8d1ca68c7aa885 # v0.3.0
+        uses: ni/python-actions/setup-poetry@5286c12d65d90b2ea738bd57d452dc4366497581 # v0.4.1
+      # If the version is 0.1.0-alpha.0, this will set the version to 0.1.0
+      - name: Promote package version to release
+        run: poetry version patch
       - name: Check project version
         if: github.event_name == 'release'
-        uses: ni/python-actions/check-project-version@97860b52be87c788fb6df812bd8d1ca68c7aa885 # v0.3.0
+        uses: ni/python-actions/check-project-version@5286c12d65d90b2ea738bd57d452dc4366497581 # v0.4.1
       - name: Build distribution packages
         run: poetry build
       - name: Upload build artifacts
@@ -34,44 +58,49 @@ jobs:
         with:
           name: ${{ env.dist-artifact-name }}
           path: dist/*
-      # @TODO: This is a workaround for there not being a way to check the lock file
-      #   See: https://github.com/python-poetry/poetry/issues/453
-      - name: Check for lock changes
-        run: |
-          poetry lock --check
-      - uses: actions/cache@v4
-        with:
-          path: ~/.cache/pypoetry/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('poetry.lock') }}
-      - name: Install the Package
-        run: poetry install
-      - name: Lint the Code
-        run: poetry run ni-python-styleguide lint
-
-      - name: Run tests
-        run: poetry run pytest -v
-
+  publish_to_pypi:
+    name: Publish package to PyPI
+    if: github.event_name == 'release' || inputs.environment != 'none'
+    runs-on: ubuntu-latest
+    needs: [build_package]
+    environment:
+      # This logic is duplicated because `name` doesn't support the `env` context.
+      name: ${{ github.event_name == 'release' && 'pypi' || inputs.environment }}
+      url: ${{ fromJson(env.environment-info)[env.environment].base-url }}/p/ni-python-styleguide
+    permissions:
+      id-token: write
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      with:
+        name: ${{ env.dist-artifact-name }}
+        path: dist/
+    - run: ls -lR
+    - name: Upload to ${{ env.environment }}
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
+      with:
+        repository-url: ${{ fromJson(env.environment-info)[env.environment].upload-url }} 
+  update_version:
+    name: Update package version to next alpha version
+    runs-on: ubuntu-latest
+    needs: [build_package]
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Check out repo
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Set up Python
+        uses: ni/python-actions/setup-python@5286c12d65d90b2ea738bd57d452dc4366497581 # v0.4.1
+      - name: Set up Poetry
+        uses: ni/python-actions/setup-poetry@5286c12d65d90b2ea738bd57d452dc4366497581 # v0.4.1
       # If the version is 0.1.0-alpha.0, this will set the version to 0.1.0
       - name: Promote package version to release
-        uses: ni/python-actions/update-project-version@97860b52be87c788fb6df812bd8d1ca68c7aa885 # v0.3.0
+        run: poetry version patch
+      - name: Update project version
+        uses: ni/python-actions/update-project-version@5286c12d65d90b2ea738bd57d452dc4366497581 # v0.4.1
         with:
-          create-pull-request: false
-          commit-message: "Bump package version to minor release version"
-          version-rule: "minor"
-      - name: Build Python package
-        if: ${{ github.event.release.target_commitish == 'main' || startsWith(github.event.release.target_commitish, 'releases/')}}
-        run: |
-          poetry build
-
-      - name: Upload Python package
-        if: ${{ github.event.release.target_commitish == 'main' || startsWith(github.event.release.target_commitish, 'releases/')}}
-        uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
-        with:
-          packages-dir: dist/
-        
-      - name: Bump poetry version to next alpha version
-        uses: ni/python-actions/update-project-version@97860b52be87c788fb6df812bd8d1ca68c7aa885 # v0.3.0
-        with:
-          create-pull-request: true
-          commit-message: "Bump package version"
+          # The default GITHUB_TOKEN cannot trigger PR workflows.
+          token: ${{ secrets.ADMIN_PAT }}
           version-rule: "prepatch"
+          use-dev-suffix: false


### PR DESCRIPTION
Publishing is currently broken due to using an old PAT.

As part of switching to OIDC based publishing, we should bring in the update ni/python-actions templates