### PR TITLE
github: Configure Renovate to group/schedule Ruby package updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,26 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-      "local>ni/python-renovate-config:recommended"
-  ]
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "local>ni/python-renovate-config:recommended"
+    ],
+    "packageRules": [
+        {
+            "description": "Update Ruby packages early Monday mornings.",
+            "matchCategories": [
+                "ruby"
+            ],
+            "matchUpdateTypes": [
+                "major",
+                "minor",
+                "patch",
+                "rollback",
+                "replacement"
+            ],
+            "groupName": "Ruby packages",
+            "groupSlug": "ruby",
+            "extends": [
+                "schedule:weekly"
+            ]
+        }
+    ]
 }


### PR DESCRIPTION
By default, Renovate updates Ruby packages in separate PRs, as soon as upstream releases new versions. This PR configures Renovate to group Ruby packages together into a single PR (plus a second PR for major-version updates) and schedules these updates for early Monday mornings.

Testing: I validated the config syntax.
```
PS C:\dev\python-styleguide> npx --yes --package renovate -- renovate-config-validator
 INFO: Validating .github/renovate.json
 INFO: Config validated successfully
```