### PR TITLE
disable upgrading flake8-import-order

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,7 +23,7 @@
             ]
         },
         {
-            "matchPackageNames": ["/flake8-import-order/"], // we're not compatible with 0.19.0 yet due to #226
+            "matchPackageNames": ["flake8-import-order"], // we're not compatible with 0.19.0 yet due to #226
             "matchManagers": ["poetry"],
             "enabled": false
         }


### PR DESCRIPTION
Renovate keeps trying to upgrade flake8-import-order, which we can't upgrade due to a breaking change that will require work to unblock. 

