### PR TITLE
mark flake8-spellcheck as a rejected plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ pep8-naming = ">=0.11.1"
 # Also describe why it is rejected and/or add a link
 # flake8-commas: Already handled by flake8-black
 # flake8-isort: Already covered by flake8-import-order
-# flake8-spellcheck: Project appears to be abandoned. No changes in 2 years, open issues from 6-4 years ago.
+# flake8-spellcheck: Project appears to be abandoned as of 2026. No changes in 2 years, open issues from 6-4 years ago.
 # hacking: Most rules are either covered by other plugins or would be turned off.
 
 


### PR DESCRIPTION
`flake8-spellcheck` appears to not provide much value. 

The project has not had commits since 2024 (2 years at the time of writing), has open issues and pull requests from 2022, some of which we would want if we were to consider adopting this (e.g., https://github.com/MichaelAquilina/flake8-spellcheck/issues/89 https://github.com/MichaelAquilina/flake8-spellcheck/issues/80 https://github.com/MichaelAquilina/flake8-spellcheck/issues/56 https://github.com/MichaelAquilina/flake8-spellcheck/issues/61 https://github.com/MichaelAquilina/flake8-spellcheck/issues/43, https://github.com/MichaelAquilina/flake8-spellcheck/issues/63)