### PR TITLE
github: Fix outdated aspects of Comment-on-PR.yml and Notify-Convention-Change.yml

### DIFF
--- a/.github/workflows/Comment-on-PR.yml
+++ b/.github/workflows/Comment-on-PR.yml
@@ -1,3 +1,5 @@
+name: Comment on PR
+
 on:
   pull_request_target:
     paths-ignore:
@@ -16,7 +18,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:

--- a/.github/workflows/Comment-on-PR.yml
+++ b/.github/workflows/Comment-on-PR.yml
@@ -19,4 +19,3 @@ jobs:
         with:
           message: |
             Thank you for contributing! :wave:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Comment-on-PR.yml
+++ b/.github/workflows/Comment-on-PR.yml
@@ -10,6 +10,9 @@ jobs:
   comment_on_pr:
     runs-on: ubuntu-latest
     name: PR comment
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/Comment-on-PR.yml
+++ b/.github/workflows/Comment-on-PR.yml
@@ -13,11 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     name: PR comment
     permissions:
-      contents: read
       pull-requests: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:

--- a/.github/workflows/Notify-Convention-Change.yml
+++ b/.github/workflows/Notify-Convention-Change.yml
@@ -20,7 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: org-check
     steps:
-      - uses: actions/checkout@main
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:

--- a/.github/workflows/Notify-Convention-Change.yml
+++ b/.github/workflows/Notify-Convention-Change.yml
@@ -43,4 +43,3 @@ jobs:
             @Adithyak1998
             @innagarc
             @ShibaniRout
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/Notify-Convention-Change.yml
+++ b/.github/workflows/Notify-Convention-Change.yml
@@ -19,6 +19,9 @@ jobs:
   notify:
     runs-on: ubuntu-latest
     needs: org-check
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/Notify-Convention-Change.yml
+++ b/.github/workflows/Notify-Convention-Change.yml
@@ -20,11 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: org-check
     permissions:
-      contents: read
       pull-requests: write
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Comment on PR
         uses: thollander/actions-comment-pull-request@24bffb9b452ba05a4f3f77933840a6a841d1b32b # v3.0.1
         with:


### PR DESCRIPTION
### What does this Pull Request accomplish?

Remove `with: GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` when calling [thollander/actions-comment-pull-request](https://github.com/thollander/actions-comment-pull-request/). This parameter was renamed from `GITHUB_TOKEN` to `github-token` in v3 and has been generating warnings ever since we upgraded, but the action has still been working without it.

Remove `uses: actions/checkout`. I'm not aware of any reason why commenting on PRs requires checking out a copy of the repo. Also, one of these workflows was using `actions/checkout@main`, which Renovate did not pin to a commit SHA because main is a branch, not a tag.

Add `permissions: pull-requests: write` so that we can lock down the repo's default permissions for GitHub Actions workflows without breaking this workflow.

Add a name for `Comment-on-PR.yml` so it doesn't show up as `.github/workflows/Comment-on-PR.yml` in the Actions tab.

### Why should this Pull Request be merged?

`Comment-on-PR.yml` and `Notify-Convention-Change.yml` use `on: pull_request_target`. When someone creates a PR from a fork, this causes the workflows to run using a GitHub token with write access to this repo, not the fork. As a result, we should ensure that these workflows do not perform unnecessary actions that expose them to the contents of the fork repo.

### What testing has been done?

I committed these changes to the default branch of my personal fork of this repo and created a PR targeting the fork. `Comment-on-PR.yml` successfully commented on the PR without `with: GITHUB_TOKEN:` or `uses: actions/checkout`.

I also tested it with "workflow permissions" set to "Read repository contents and packages permissions".