### PR TITLE
Bring black pin forward from 0.4.x

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -657,4 +657,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "64cb3e880c75fddee5c07dccd497490b9301f551c498bcf2a4a15963ce7ce9bd"
+content-hash = "7b22b0ed66957b9de172675b36eda4bdce1864dd22917e6d860c1f5c7a2f1bf4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ pycodestyle = [
     {version = "^2.9", python = ">=3.8,<3.12"},
     {version = "^2.11", python = "^3.12"},
 ]
-black = ">=23.1"
+black = ">=23.1,<26.0" # 26.0 introduces formatting changes, but drops support for Python < 3.10, so pin to version that has consistent formatting across 3.9-3.14
 better-diff = "^0.1.3"
 
 # Additional support libraries


### PR DESCRIPTION
Since we are still supporting Python 3.9 for (at least) one more release, pin black version to ensure consistent formatting across Python 3.9-3.14.