### PR TITLE
chore: Update project ni-python-styleguide to v0.5.1a0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "ni-python-styleguide"
 # The a.0 here denotes a source based version
 # This is removed when released through the Publish-Package.yml GitHub action
 # Official PyPI releases follow Major.Minor.Patch
-version = "0.5.0a0"
+version = "0.5.1a0"
 description = "NI's internal and external Python linter rules and plugins"
 authors = ["NI <opensource@ni.com>"]
 readme = "README.md" # apply the repo readme to the package as well


### PR DESCRIPTION
This PR updates the versions of the following Python projects:

| Project | Version | Path |
|---------|---------|------|
| ni-python-styleguide | 0.5.1a0 | pyproject.toml |

If the checks for this pull request appear to hang, you can work around this by closing and re-opening the PR. See
[ni/python-actions/update-project-version >> Inputs >> token](https://github.com/ni/python-actions/tree/aa64e60612cb078b0c2ada666becbd70d4817d55/update-project-version#token) and 
[create-pull-request >> Triggering further workflow runs](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs)
for more details.

This PR was generated by [ni/python-actions/update-project-version](https://github.com/ni/python-actions/tree/aa64e60612cb078b0c2ada666becbd70d4817d55/update-project-version). View the [workflow log](https://github.com/ni/python-styleguide/actions/runs/25868665009).