### PR TITLE
update changelog and review instructions

### DIFF
--- a/.github/copilot/instructions.md
+++ b/.github/copilot/instructions.md
@@ -1,0 +1,35 @@
+# GitHub Copilot Code Review Instructions
+
+## Overview
+These instructions guide code review analysis for pull requests, focusing on security, style consistency, and documentation completeness.
+
+## Review Checklist
+
+### 1. Security Issues
+- **Input Validation**: Verify that user inputs, external data, and file contents are properly validated and sanitized
+- **Injection Attacks**: Check for SQL injection, command injection, and code injection vulnerabilities
+- **Sensitive Data**: Ensure no hardcoded secrets, API keys, passwords, or sensitive credentials are exposed
+- **Dependency Vulnerabilities**: Flag any deprecated or vulnerable dependencies
+- **Access Control**: Verify proper authentication and authorization checks are in place
+- **Error Handling**: Check that error messages don't leak sensitive information
+- **File Operations**: Ensure safe file handling with proper path validation and permissions checks
+
+### 2. Style Consistency
+- **Naming Conventions**: Check that variables, functions, and classes follow project naming conventions
+- **Documentation**: Verify docstrings are present in the public API and follow project conventions
+- **Consistency with Existing Code**: Ensure new code matches the style and patterns used elsewhere in the project
+
+### 3. Changelog Updates
+- **Behavioral Changes**: Verify that any changes to existing functionality are documented in CHANGELOG.md
+- **Public API Changes**: Ensure additions, modifications, or removals of public APIs are logged
+- **Breaking Changes**: Flag breaking changes and verify they are clearly documented
+- **New Features**: Confirm new features are added to the changelog
+- **Bug Fixes**: Check that significant bug fixes are documented
+- **Versioning**: Verify that version updates align with semantic versioning principles
+
+## Reporting
+When reviewing code, provide clear feedback indicating:
+- Which category the issue falls under (Security, Style, or Changelog)
+- The specific concern or violation
+- A suggestion for resolution where applicable
+- Severity level (critical, high, medium, low)

--- a/.instructions.md
+++ b/.instructions.md
@@ -1,0 +1,3 @@
+# GitHub Copilot Code Review Instructions
+
+- Load the instructions file from .github/copilot/instructions.md

--- a/.instructions.md
+++ b/.instructions.md
@@ -1,3 +1,3 @@
 # GitHub Copilot Code Review Instructions
 
-- Load the instructions file from .github/copilot/instructions.md
+- Load the instructions file from [.github/copilot/instructions.md](.github/copilot/instructions.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -281,7 +281,8 @@ Release pipeline was broken, retrigger push to pypi.org
 ### Added
 - Initial Release 🚀
 
-[Unreleased]: https://github.com/ni/python-styleguide/compare/v0.4.9...main
+[Unreleased]: https://github.com/ni/python-styleguide/compare/v0.5.0...main
+[0.5.0]: https://github.com/ni/python-styleguide/compare/v0.4.9...v0.5.0
 [0.4.9]: https://github.com/ni/python-styleguide/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/ni/python-styleguide/compare/v0.4.7...v0.4.8
 [0.4.7]: https://github.com/ni/python-styleguide/compare/v0.4.6...v0.4.7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.1] - unreleased
+## [Unreleased]
+
+### Changed
 
 - Update flake8-import-order to remove warnings from output (#305)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.5.1] - unreleased
+
+- Update flake8-import-order to remove warnings from output (#305)
+
+## [0.5.0] - 2026-05-14
 
 ### Added
 - Add vim/neovim integration instructions to README (#205)


### PR DESCRIPTION
Document the update of `flake8-import-order` to remove warnings in `CHANGELOG.md` under the unreleased section as preparation for releasing 0.5.1.

Also add instructions for copilot to review if the changelog is out of date.