### PR TITLE
Ignore linting the .build/ai directory

### DIFF
--- a/ni_python_styleguide/config.ini
+++ b/ni_python_styleguide/config.ini
@@ -117,6 +117,8 @@ per-file-ignores=
     tests/**/test_*.py,tests/test_*.py:D100,D103,D102
     # We don't need to document every Sphinx config
     docs/conf.py:D1
+    # We don't need to document AI scripts
+    .build/ai/**:D1
     # __init__.py files routinely import other modules without directly using them
     __init__.py:F401
 


### PR DESCRIPTION
# Justification
Copilot creates ad-hoc scripts in the project's `.build/ai` directory. This is causing linters (ni-python-styleguide, flake8) to flag issues in these scripts when run in the project even though we aren't checking in that code.

# Implementation
Ignore linting the `.build/ai` directory