### PR TITLE
chore: promote changelog for 0.5.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1] - 2026-07-17
+
 ### Changed
 
 - Update flake8-import-order to remove warnings from output (#305)
@@ -281,7 +283,8 @@ Release pipeline was broken, retrigger push to pypi.org
 ### Added
 - Initial Release 🚀
 
-[Unreleased]: https://github.com/ni/python-styleguide/compare/v0.5.0...main
+[Unreleased]: https://github.com/ni/python-styleguide/compare/v0.5.1...main
+[0.5.1]: https://github.com/ni/python-styleguide/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/ni/python-styleguide/compare/v0.4.9...v0.5.0
 [0.4.9]: https://github.com/ni/python-styleguide/compare/v0.4.8...v0.4.9
 [0.4.8]: https://github.com/ni/python-styleguide/compare/v0.4.7...v0.4.8


### PR DESCRIPTION
Update changelog to prepare for 0.5.1 release build and tag