### PR TITLE
Ignore I300 and I301

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Ignore I300 and I301 in favor of BLK100 (#327)
+
 ## [0.5.1] - 2026-07-17
 
 ### Changed

--- a/ni_python_styleguide/config.ini
+++ b/ni_python_styleguide/config.ini
@@ -111,6 +111,9 @@ ignore =
     # flake8-import-order
     # I101 - The names in your from import are in the wrong order. (Enforced by E401)
     I101
+    # I300, I301 - Blank lines around imports and if TYPE_CHECKING. We will use BLK100
+    I300
+    I301
 
 per-file-ignores=
     # We want to ignore missing docstrings in test methods as they are self documenting


### PR DESCRIPTION
flake8-import-order recently added I300 and has I301 proposed.

I300 is 

> TYPE_CHECKING block should have one newline above

I301 will probably be 

> TYPE_CHECKING block should have no more than one newline above

&nbsp;

Both of these code conflict with our chosen formatting layout standard of `black`.

So ignore both in favor of `BLK100`
